### PR TITLE
bump to v0.1.2 for subspace cli

### DIFF
--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -67,7 +67,7 @@ Compiled versions of the Subspace CLI is [hosted on GitHub](https://github.com/s
 <div className={styles.buttons}>
     <Link
     className="button button--secondary button"
-    to="https://github.com/subspace/subspace-cli/releases/download/v0.1.1-alpha/subspace-cli-windows-x86_64-v0.1.1-alpha.exe">
+    to="https://github.com/subspace/subspace-cli/releases/download/v0.1.2-alpha/subspace-cli-windows-x86_64-v0.1.2-alpha.exe">
     Windows CLI Executable
     </Link>
 </div>
@@ -83,19 +83,19 @@ Compiled versions of the Subspace CLI is [hosted on GitHub](https://github.com/s
 <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.1-alpha/subspace-cli-macos-x86_64-v0.1.1-alpha.zip">
+        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.2-alpha/subspace-cli-macos-x86_64-v0.1.2-alpha.zip">
         Mac CLI Executable (Intel)
     </Link>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.1-alpha/subspace-cli-macos-aarch64-v0.1.1-alpha.zip">
+        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.2-alpha/subspace-cli-macos-aarch64-v0.1.2-alpha.zip">
         Mac CLI Executable (Apple M1)
     </Link>
 </div>
 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
-4. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.1-alpha`.
+4. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.2-alpha`.
 
 </TabItem>
 <TabItem value="linux" label="🐧Ubuntu">
@@ -105,18 +105,18 @@ Compiled versions of the Subspace CLI is [hosted on GitHub](https://github.com/s
 <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.1-alpha/subspace-cli-Ubuntu-x86_64-v0.1.1-alpha">
+        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.2-alpha/subspace-cli-Ubuntu-x86_64-v0.1.2-alpha">
         Ubuntu Executable
     </Link>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.1-alpha/subspace-cli-ubuntu-aarch64-v0.1.1-alpha">
+        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.2-alpha/subspace-cli-ubuntu-aarch64-v0.1.2-alpha">
         Linux Arch Executable
     </Link>
 </div>
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
-3. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.1-alpha`.
+3. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.2-alpha`.
 
 
 </TabItem>
@@ -133,7 +133,7 @@ To start we will have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-subspace-cli-windows-x86_64-v0.1.1-alpha init
+subspace-cli-windows-x86_64-v0.1.2-alpha init
 ```
 
 </TabItem>
@@ -141,7 +141,7 @@ subspace-cli-windows-x86_64-v0.1.1-alpha init
 <TabItem value="macos" label="🍎 macOS">
 
 ```bash
-subspace-cli-macos-x86_64-v0.1.1-alpha init
+subspace-cli-macos-x86_64-v0.1.2-alpha init
 ```
 
 </TabItem>
@@ -149,7 +149,7 @@ subspace-cli-macos-x86_64-v0.1.1-alpha init
 <TabItem value="linux" label="🐧 Ubuntu">
 
 ```bash
-subspace-cli-ubuntu-x86_64-v0.1.1-alpha init
+subspace-cli-ubuntu-x86_64-v0.1.2-alpha init
 ```
 
 </TabItem>
@@ -158,7 +158,7 @@ subspace-cli-ubuntu-x86_64-v0.1.1-alpha init
 This will prompt you to setup your CLI configurations to begin farming. You should see a similar prompt like so:
 
 ```bash
-$ ./subspace-cli-ubuntu-x86_64-v0.1.1-alpha init
+$ ./subspace-cli-ubuntu-x86_64-v0.1.2-alpha init
 
 version: 0.1.0
 
@@ -249,7 +249,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./subspace-cli-windows-x86_64-v0.1.1-alpha farm
+./subspace-cli-windows-x86_64-v0.1.2-alpha farm
 ```
 
 </TabItem>
@@ -257,7 +257,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="macos" label="🍎 macOS">
 
 ```bash
-./subspace-cli-macos-x86_64-v0.1.1-alpha farm
+./subspace-cli-macos-x86_64-v0.1.2-alpha farm
 ```
 
 </TabItem>
@@ -265,7 +265,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="linux" label="🐧 Ubuntu">
 
 ```bash
-./subspace-cli-ubuntu-x86_64-v0.1.1-alpha farm
+./subspace-cli-ubuntu-x86_64-v0.1.2-alpha farm
 ```
 
 </TabItem>
@@ -274,7 +274,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 You should see the farmer and node start successfully and begin syncing, plotting, and then farming:
 
 ```bash
-$ ./subspace-cli-ubuntu-x86_64-v0.1.1-alpha farm
+$ ./subspace-cli-ubuntu-x86_64-v0.1.2-alpha farm
 Starting node ... (this might take up to couple of minutes)
 Node started successfully!
 Starting farmer ...


### PR DESCRIPTION
This updates our links to the Subspace CLI to the latest version, `v0.1.2-alpha`