### PR TITLE
enable dark-mode default, fix Windows CLI commands, additional CLI commands for M1 Chip and Linux Arch users

### DIFF
--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -321,3 +321,54 @@ Initial plotting for plot: #0 (/home/username/.local/share/subspace-cli/plots)
 ```
 
 That's it! Enjoy and Happy Farming!
+
+#### Moving the Farming Process to the Background
+
+<Tabs groupId="OS">
+<TabItem value="tmux" label="tmux" default>
+
+* Create a new tmux session using a socket file named farming
+
+```bash
+$ tmux -S farming
+```
+
+
+* Move process to background by detaching
+```bash
+Ctrl+b d OR ⌘+b d (Mac)
+```
+
+* To re-attach
+```bash
+$ tmux -S farming attach 
+```
+
+* To delete farming session
+```bash
+$ tmux kill-session -t farming
+```
+
+</TabItem>
+<TabItem value="screen" label="screen">
+
+* Create new screen using a socket file named farming
+```bash
+$ screen -S farming 
+```
+
+* Move process to background by detaching
+```bash
+Ctrl+d a OR ⌘+d a (Mac)
+```
+
+* To re-attach
+```bash
+$ screen -r farming 
+```
+* To delete farming session
+```bash
+$ screen -S farming -X quit
+```
+</TabItem>
+</Tabs>

--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -271,7 +271,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./subspace-cli-windows-x86_64-v0.1.3-alpha farm
+./subspace-cli-windows-x86_64-v0.1.3-alpha.exe farm
 ```
 
 </TabItem>

--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -108,7 +108,9 @@ Compiled versions of the Subspace CLI is [hosted on GitHub](https://github.com/s
 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
-4. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.3-alpha`.
+4. Make the binary executable by running:
+    * `chmod +x subspace-cli-macos-x86_64-v0.1.3-alpha` (Intel Chip) 
+    * `chmod +x subspace-cli-macos-aarch64-v0.1.3-alpha` (Apple M1 Chip)
 
 </TabItem>
 <TabItem value="linux" label="🐧Ubuntu">
@@ -129,7 +131,9 @@ Compiled versions of the Subspace CLI is [hosted on GitHub](https://github.com/s
 </div>
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
-3. Make the binary executable by running `chmod +x subspace-cli-macos-x86_64-v0.1.3-alpha`.
+3. Make the binary executable by running:
+    * `chmod +x    subspace-cli-ubuntu-x86_64-v0.1.3-alpha` (Ubuntu) 
+    * `chmod +x subspace-cli-ubuntu-aarch64-v0.1.3-alpha` (Linux Arch)
 
 </TabItem>
 
@@ -145,23 +149,35 @@ To start we will have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-subspace-cli-windows-x86_64-v0.1.3-alpha init
+subspace-cli-windows-x86_64-v0.1.3-alpha.exe init
 ```
 
 </TabItem>
 
 <TabItem value="macos" label="🍎 macOS">
+Intel Chip:
 
 ```bash
 subspace-cli-macos-x86_64-v0.1.3-alpha init
+```
+Apple M1 Chip:
+
+```bash
+subspace-cli-macos-aarch64-v0.1.3-alpha init
 ```
 
 </TabItem>
 
 <TabItem value="linux" label="🐧 Ubuntu">
+Ubuntu:
 
 ```bash
 subspace-cli-ubuntu-x86_64-v0.1.3-alpha init
+```
+Linux Arch:
+
+```bash
+subspace-cli-ubuntu-aarch64-v0.1.3-alpha init
 ```
 
 </TabItem>
@@ -262,16 +278,30 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 
 <TabItem value="macos" label="🍎 macOS">
 
+Intel Chip:
+
 ```bash
-./subspace-cli-macos-x86_64-v0.1.3-alpha farm
+subspace-cli-macos-x86_64-v0.1.3-alpha farm
+```
+Apple M1 Chip:
+
+```bash
+subspace-cli-macos-aarch64-v0.1.3-alpha farm
 ```
 
 </TabItem>
 
 <TabItem value="linux" label="🐧 Ubuntu">
 
+Ubuntu:
+
 ```bash
-./subspace-cli-ubuntu-x86_64-v0.1.3-alpha farm
+subspace-cli-ubuntu-x86_64-v0.1.3-alpha farm
+```
+Linux Arch:
+
+```bash
+subspace-cli-ubuntu-aarch64-v0.1.3-alpha farm
 ```
 
 </TabItem>

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -64,6 +64,9 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      colorMode:{
+        defaultMode: 'dark'
+      },
       navbar: {
         title: 'Subspace',
         logo: {


### PR DESCRIPTION
Fixes issue #128, added colorMode config in themeConfigs.

Second and third commit fixes issue #133, correcting the Windows CLI commands. Extra CLI commands were added to simplify farming set-up process for M1 Chip, Linux Arch users.

Fourth commit fixes issue #131, adding tmux and screen instructions