### PR TITLE
Fix case error in filename link

### DIFF
--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -140,7 +140,7 @@ Your Mac may not let you open/initialize the file because of unidentified develo
 <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.9-alpha/subspace-cli-Ubuntu-x86_64-v0.1.9-alpha">
+        to="https://github.com/subspace/subspace-cli/releases/download/v0.1.9-alpha/subspace-cli-ubuntu-x86_64-v0.1.9-alpha">
         Ubuntu Executable
     </Link>
     <Link


### PR DESCRIPTION
As reported in Discord, there is a small case error in the name of the CLI executable on the documentation website. This fixes that error which should prevent confusion when the binary has a different name to that used in the run command when following the docs.