### PR TITLE
Increase number of Docker healthcheck retries from 5 to 60

### DIFF
--- a/docker-compose-auto.yml
+++ b/docker-compose-auto.yml
@@ -32,7 +32,7 @@ services:
       timeout: 5s
 # If node setup takes longer then expected, you want to increase `interval` and `retries` number.
       interval: 30s
-      retries: 5
+      retries: 60
 
   farmer:
     depends_on:

--- a/docs/protocol/substrate-cli.md
+++ b/docs/protocol/substrate-cli.md
@@ -152,7 +152,7 @@ We will be downloading two files for your respective operating system.
           timeout: 5s
     # If node setup takes longer than expected, you want to increase `interval` and `retries` number.
           interval: 30s
-          retries: 5
+          retries: 60
 
       farmer:
         depends_on:


### PR DESCRIPTION
To align with the same change made in the monorepo [Increase number of Docker healthcheck retries from 5 to 60 #1637](https://github.com/subspace/subspace/pull/1637).