### PR TITLE
Subspace Terminology Changes

### DIFF
--- a/docker-compose-auto.yml
+++ b/docker-compose-auto.yml
@@ -25,7 +25,7 @@ services:
       "--rpc-methods", "safe",
       "--unsafe-ws-external",
       "--validator",
-# Replace `INSERT_YOUR_ID` with your node ID (will be shown in telemetry)
+# Replace `INSERT_YOUR_ID` with your node ID (will be shown in Substation, our telemetry server)
       "--name", "INSERT_YOUR_ID"
     ]
     healthcheck:

--- a/docs/protocol/cli.md
+++ b/docs/protocol/cli.md
@@ -1,5 +1,5 @@
 ---
-title: Simple CLI (Recommended)
+title: Pulsar (Recommended)
 sidebar_position: 2
 description: Farming on the Subspace Network
 keywords:
@@ -16,7 +16,7 @@ import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
 :::tip Recommended
-Simple CLI also known as [Subspace CLI](https://github.com/subspace/subspace-cli) is the recommended way to farm on the Subspace Network. To get started, follow the guide below. For more information, you can check out the project [README on GitHub](https://github.com/subspace/subspace-cli/blob/main/README.md).
+Pulsar also known as [Subspace Simple CLI](https://github.com/subspace/subspace-cli) is the recommended way to farm on the Subspace Network. To get started, follow the guide below. For more information, you can check out the project [README on GitHub](https://github.com/subspace/subspace-cli/blob/main/README.md).
 :::
 
 ## Pre-Requisites

--- a/docs/protocol/substrate-cli.md
+++ b/docs/protocol/substrate-cli.md
@@ -604,7 +604,7 @@ Now that your Node & Farmer have been started you will wait for the node to sync
 **- [Substation Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
 
 
-**- [Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**
+**- [Astral Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**
 
 
 ### Using a Custom Path

--- a/docs/protocol/substrate-cli.md
+++ b/docs/protocol/substrate-cli.md
@@ -260,7 +260,7 @@ We will be downloading two files for your respective operating system.
   .\subspace-node-windows-x86_64-skylake-gemini-3e-2023-jul-03.exe `
     --chain gemini-3e `
     --execution wasm `
-    --blocks-pruning archive `
+    --blocks-pruning 256 `
     --state-pruning archive `
     --dsn-disable-private-ips `
     --no-private-ipv4 `
@@ -382,7 +382,7 @@ We will be downloading two files for your respective operating system.
   ./subspace-node-macos-x86_64-gemini-3e-2023-jul-03 \
     --chain gemini-3e \
     --execution wasm \
-    --blocks-pruning archive \
+    --blocks-pruning 256 \
     --state-pruning archive \
     --dsn-disable-private-ips \
     --no-private-ipv4 \
@@ -534,7 +534,7 @@ We will be downloading two files for your respective operating system.
   ./subspace-node-ubuntu-x86_64-skylake-gemini-3e-2023-jul-03 \
     --chain gemini-3e \
     --execution wasm \
-    --blocks-pruning archive \
+    --blocks-pruning 256 \
     --state-pruning archive \
     --dsn-disable-private-ips \
     --no-private-ipv4 \

--- a/docs/protocol/substrate-cli.md
+++ b/docs/protocol/substrate-cli.md
@@ -145,7 +145,7 @@ We will be downloading two files for your respective operating system.
           "--rpc-cors", "all",
           "--unsafe-rpc-external",
           "--rpc-methods", "safe",
-    # Replace `INSERT_YOUR_ID` with your node ID (will be shown in telemetry)
+    # Replace `INSERT_YOUR_ID` with your node ID (will be shown in Substation, our telemetry)
           "--name", "INSERT_YOUR_ID"
         ]
         healthcheck:
@@ -189,7 +189,7 @@ We will be downloading two files for your respective operating system.
 
   2. Now edit created file:
 
-  a. Replace `INSERT_YOUR_ID` with desired name that will be shown in telemetry (doesn't impact anything else)
+  a. Replace `INSERT_YOUR_ID` with desired name that will be shown in Substation, our telemetry server (doesn't impact anything else)
 
   b. Replace `WALLET_ADDRESS` with your wallet address
 
@@ -601,7 +601,7 @@ We will be downloading two files for your respective operating system.
 
 Now that your Node & Farmer have been started you will wait for the node to sync and the farmer to complete the initial plotting. While this is occurring you can check out some of the helpful resources below.
 
-**- [Telemetry Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
+**- [Substation Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
 
 
 **- [Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**

--- a/docs/protocol/wallets/subwallet.md
+++ b/docs/protocol/wallets/subwallet.md
@@ -98,7 +98,7 @@ SubWallet supports adding custom networks. This can be helpful for in-developmen
     - Provider URL
     - Network Name
     - Symbol
-    - Block explorer
+    - Astral Explorer
     - Crowdloan URL
 
     The only option that is required is the Provider URL. You can add an explorer if you would like but it is not required. (The current Subspace Explorer is available [here](https://explorer.subspace.network).

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -105,7 +105,7 @@ const config = {
             position: 'left',
             items: [
               {
-                label: 'Subspace Telemetry',
+                label: 'Substation Telemetry',
                 href: 'https://telemetry.subspace.network',
               },
               {

--- a/versioned_docs/version-latest/protocol/cli.md
+++ b/versioned_docs/version-latest/protocol/cli.md
@@ -1,5 +1,5 @@
 ---
-title: Simple CLI (Recommended)
+title: Pulsar (Recommended)
 sidebar_position: 2
 description: Farming on the Subspace Network
 keywords:
@@ -16,7 +16,7 @@ import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
 :::tip Recommended
-Simple CLI also known as [Subspace CLI](https://github.com/subspace/subspace-cli) is the recommended way to farm on the Subspace Network. To get started, follow the guide below. For more information, you can check out the project [README on GitHub](https://github.com/subspace/subspace-cli/blob/main/README.md).
+Pulsar also known as [Subspace Simple CLI](https://github.com/subspace/subspace-cli) is the recommended way to farm on the Subspace Network. To get started, follow the guide below. For more information, you can check out the project [README on GitHub](https://github.com/subspace/subspace-cli/blob/main/README.md).
 :::
 
 ## Pre-Requisites

--- a/versioned_docs/version-latest/protocol/substrate-cli.md
+++ b/versioned_docs/version-latest/protocol/substrate-cli.md
@@ -604,7 +604,7 @@ Now that your Node & Farmer have been started you will wait for the node to sync
 **- [Substation Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
 
 
-**- [Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**
+**- [Astral Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**
 
 
 ### Using a Custom Path

--- a/versioned_docs/version-latest/protocol/substrate-cli.md
+++ b/versioned_docs/version-latest/protocol/substrate-cli.md
@@ -145,7 +145,7 @@ We will be downloading two files for your respective operating system.
           "--rpc-cors", "all",
           "--unsafe-rpc-external",
           "--rpc-methods", "safe",
-    # Replace `INSERT_YOUR_ID` with your node ID (will be shown in telemetry)
+    # Replace `INSERT_YOUR_ID` with your node ID (will be shown in Substation, our telemetry server)
           "--name", "INSERT_YOUR_ID"
         ]
         healthcheck:
@@ -189,7 +189,7 @@ We will be downloading two files for your respective operating system.
 
   2. Now edit created file:
 
-  a. Replace `INSERT_YOUR_ID` with desired name that will be shown in telemetry (doesn't impact anything else)
+  a. Replace `INSERT_YOUR_ID` with desired name that will be shown in Substation, our telemetry server (doesn't impact anything else)
 
   b. Replace `WALLET_ADDRESS` with your wallet address
 
@@ -601,7 +601,7 @@ We will be downloading two files for your respective operating system.
 
 Now that your Node & Farmer have been started you will wait for the node to sync and the farmer to complete the initial plotting. While this is occurring you can check out some of the helpful resources below.
 
-**- [Telemetry Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
+**- [Substation Server](https://telemetry.subspace.network/#list/0xa3cd4b592d93f79943fbc58fc90ca8f516106699c9cf4d7ada98ca22877bc1ae)**
 
 
 **- [Block Explorer](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Frpc-0.gemini-3e.subspace.network%2Fws#/explorer)**

--- a/versioned_docs/version-latest/protocol/wallets/subwallet.md
+++ b/versioned_docs/version-latest/protocol/wallets/subwallet.md
@@ -98,7 +98,7 @@ SubWallet supports adding custom networks. This can be helpful for in-developmen
     - Provider URL
     - Network Name
     - Symbol
-    - Block explorer
+    - Astral Explorer
     - Crowdloan URL
 
     The only option that is required is the Provider URL. You can add an explorer if you would like but it is not required. (The current Subspace Explorer is available [here](https://explorer.subspace.network).


### PR DESCRIPTION
## Renaming Components
As part of our ongoing efforts to align terminology with the evolving structure and vision of our project, we have renamed the following components:

**Telemetry** is now **Substation**: 
This change reflects a shift in functionality and better represents the role of this component within the system.

**Block Explorer** has been renamed to **Astral Explorer**: 
This new name encapsulates the expanded capabilities and the innovative approach we are taking with this tool.

**Simple CLI** has been updated to **Pulsar**: 
The new name signifies the enhanced features and the streamlined interface that Pulsar offers.

### Wallet Renaming Status
Please note that we have not renamed the wallet component as of yet. We are currently waiting for more information and will proceed with the renaming once all necessary details and considerations have been finalized.

We encourage team members to review these changes and provide feedback if necessary. Your collaboration and insights are vital as we continue to refine and improve our system.


## Updated Block-Pruning

As per this PR https://github.com/subspace/subspace/pull/1784 Ive updated the block-pruning value from archive to 256, This has only been done in the pre-release version and current latest does not support this yet. (we'll cut a new version at next snapshot)