### PR TITLE
Updates Pulsar from `v0.6.3-alpha` to `v0.6.4-alpha` & Remove Deprecated command

### DIFF
--- a/docs/protocol/pulsar.mdx
+++ b/docs/protocol/pulsar.mdx
@@ -151,7 +151,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-windows-x86_64-v2-v0.6.3-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-windows-x86_64-v2-v0.6.4-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -164,7 +164,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -198,7 +198,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-macos-x86_64-v0.6.3-alpha.zip">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-macos-x86_64-v0.6.4-alpha.zip">
       Mac CLI Executable (Intel)
     </Link>
   </div>
@@ -211,7 +211,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-macos-aarch64-v0.6.3-alpha.zip">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-macos-aarch64-v0.6.4-alpha.zip">
         Mac CLI Executable (Apple M Series)
     </Link>
   </div>
@@ -220,8 +220,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 4. Make the binary executable by running:
-    * `chmod +x pulsar-macos-x86_64-v0.6.3-alpha` (Intel Chip)
-    * `chmod +x pulsar-macos-aarch64-v0.6.3-alpha` (Apple M Series)
+    * `chmod +x pulsar-macos-x86_64-v0.6.4-alpha` (Intel Chip)
+    * `chmod +x pulsar-macos-aarch64-v0.6.4-alpha` (Apple M Series)
 
 :::warning
 Your Mac may not let you open/initialize the file because of unidentified developer restrictions. To resolve this, go to Settings-> Security&Privacy -> General -> Allow
@@ -248,7 +248,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-x86_64-v2-v0.6.3-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-x86_64-v2-v0.6.4-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -260,7 +260,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -274,7 +274,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-aarch64-v0.6.3-alpha">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-aarch64-v0.6.4-alpha">
         Ubuntu Executable (aarch64)
     </Link>
   </div>
@@ -282,8 +282,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 3. Make the binary executable by running:
-	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha` (Ubuntu)
-    * `chmod +x pulsar-ubuntu-aarch64-v0.6.3-alpha` (Ubuntu aarch64)
+	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha` (Ubuntu)
+    * `chmod +x pulsar-ubuntu-aarch64-v0.6.4-alpha` (Ubuntu aarch64)
 
 </TabItem>
 
@@ -299,7 +299,7 @@ To start we have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe init
+./pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe init
 ```
 
 :::note High RAM consumption
@@ -315,14 +315,14 @@ Intel Chip:
 
 ```bash
 
-./pulsar-macos-x86_64-v0.6.3-alpha  init
+./pulsar-macos-x86_64-v0.6.4-alpha  init
 
 ```
 Apple M Series:
 
 ```bash
 
-./pulsar-macos-aarch64-v0.6.3-alpha init
+./pulsar-macos-aarch64-v0.6.4-alpha init
 
 ```
 
@@ -333,14 +333,14 @@ Ubuntu:
 
 ```bash
 
-./pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha  init
+./pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha  init
 
 ```
 Ubuntu Executable (aarch64):
 
 ```bash
 
-./pulsar-ubuntu-aarch64-v0.6.3-alpha  init
+./pulsar-ubuntu-aarch64-v0.6.4-alpha  init
 
 ```
 
@@ -429,7 +429,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe farm
+./pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe farm
 ```
 
 </TabItem>
@@ -440,14 +440,14 @@ Intel Chip:
 
 ```bash
 
-./pulsar-macos-x86_64-v0.6.3-alpha farm
+./pulsar-macos-x86_64-v0.6.4-alpha farm
 
 ```
 Apple M1 Chip:
 
 ```bash
 
-./pulsar-macos-aarch64-v0.6.3-alpha farm
+./pulsar-macos-aarch64-v0.6.4-alpha farm
 
 ```
 
@@ -459,14 +459,14 @@ Ubuntu:
 
 ```bash
 
-./pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha farm
+./pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha farm
 
 ```
 Ubuntu Executable (aarch64):
 
 ```bash
 
-./pulsar-ubuntu-aarch64-v0.6.3-alpha farm
+./pulsar-ubuntu-aarch64-v0.6.4-alpha farm
 
 ```
 

--- a/docs/protocol/substrate-cli.mdx
+++ b/docs/protocol/substrate-cli.mdx
@@ -220,7 +220,6 @@ We will be downloading two files for your respective operating system.
     --execution wasm `
     --blocks-pruning 256 `
     --state-pruning archive `
-    --no-private-ipv4 `
     --validator `
     --name "INSERT_YOUR_ID"
   ```
@@ -341,7 +340,6 @@ We will be downloading two files for your respective operating system.
     --execution wasm \
     --blocks-pruning 256 \
     --state-pruning archive \
-    --no-private-ipv4 \
     --validator \
     --name "INSERT_YOUR_ID"
   ```
@@ -493,7 +491,6 @@ We will be downloading two files for your respective operating system.
       --execution wasm \
       --blocks-pruning 256 \
       --state-pruning archive \
-      --no-private-ipv4 \
       --validator \
       --name "INSERT_YOUR_ID"
   ```

--- a/src/components/DockerFileGenerator/index.jsx
+++ b/src/components/DockerFileGenerator/index.jsx
@@ -119,7 +119,6 @@ services:
         "--rpc-cors", "all",
         "--rpc-methods", "unsafe",
         "--rpc-external",
-        "--no-private-ipv4",
         "--validator",
         "--name", "${formData.nodeName}"
       ]

--- a/versioned_docs/version-latest/protocol/pulsar.mdx
+++ b/versioned_docs/version-latest/protocol/pulsar.mdx
@@ -151,7 +151,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-windows-x86_64-v2-v0.6.3-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-windows-x86_64-v2-v0.6.4-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -164,7 +164,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -196,7 +196,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-macos-x86_64-v0.6.3-alpha.zip">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-macos-x86_64-v0.6.4-alpha.zip">
       Mac CLI Executable (Intel)
     </Link>
   </div>
@@ -209,7 +209,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-macos-aarch64-v0.6.3-alpha.zip">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-macos-aarch64-v0.6.4-alpha.zip">
         Mac CLI Executable (Apple M Series)
     </Link>
   </div>
@@ -218,8 +218,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 4. Make the binary executable by running:
-    * `chmod +x pulsar-macos-x86_64-v0.6.3-alpha` (Intel Chip)
-    * `chmod +x pulsar-macos-aarch64-v0.6.3-alpha` (Apple M Series)
+    * `chmod +x pulsar-macos-x86_64-v0.6.4-alpha` (Intel Chip)
+    * `chmod +x pulsar-macos-aarch64-v0.6.4-alpha` (Apple M Series)
 
 :::warning
 Your Mac may not let you open/initialize the file because of unidentified developer restrictions. To resolve this, go to Settings-> Security&Privacy -> General -> Allow
@@ -246,7 +246,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-x86_64-v2-v0.6.3-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-x86_64-v2-v0.6.4-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -258,7 +258,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -272,7 +272,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.3-alpha/pulsar-ubuntu-aarch64-v0.6.3-alpha">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.4-alpha/pulsar-ubuntu-aarch64-v0.6.4-alpha">
         Ubuntu Executable (aarch64)
     </Link>
   </div>
@@ -280,8 +280,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 3. Make the binary executable by running:
-	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha` (Ubuntu)
-    * `chmod +x pulsar-ubuntu-aarch64-v0.6.3-alpha` (Ubuntu aarch64)
+	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha` (Ubuntu)
+    * `chmod +x pulsar-ubuntu-aarch64-v0.6.4-alpha` (Ubuntu aarch64)
 
 </TabItem>
 
@@ -297,7 +297,7 @@ To start we have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe init
+./pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe init
 ```
 
 :::note High RAM consumption
@@ -313,14 +313,14 @@ Intel Chip:
 
 ```bash
 
-./pulsar-macos-x86_64-v0.6.3-alpha  init
+./pulsar-macos-x86_64-v0.6.4-alpha  init
 
 ```
 Apple M Series:
 
 ```bash
 
-./pulsar-macos-aarch64-v0.6.3-alpha init
+./pulsar-macos-aarch64-v0.6.4-alpha init
 
 ```
 
@@ -331,14 +331,14 @@ Ubuntu:
 
 ```bash
 
-./pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha  init
+./pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha  init
 
 ```
 Ubuntu Executable (aarch64):
 
 ```bash
 
-./pulsar-ubuntu-aarch64-v0.6.3-alpha  init
+./pulsar-ubuntu-aarch64-v0.6.4-alpha  init
 
 ```
 
@@ -427,7 +427,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.3-alpha.exe farm
+./pulsar-windows-x86_64-skylake-v0.6.4-alpha.exe farm
 ```
 
 </TabItem>
@@ -438,14 +438,14 @@ Intel Chip:
 
 ```bash
 
-./pulsar-macos-x86_64-v0.6.3-alpha farm
+./pulsar-macos-x86_64-v0.6.4-alpha farm
 
 ```
 Apple M1 Chip:
 
 ```bash
 
-./pulsar-macos-aarch64-v0.6.3-alpha farm
+./pulsar-macos-aarch64-v0.6.4-alpha farm
 
 ```
 
@@ -457,14 +457,14 @@ Ubuntu:
 
 ```bash
 
-./pulsar-ubuntu-x86_64-skylake-v0.6.3-alpha farm
+./pulsar-ubuntu-x86_64-skylake-v0.6.4-alpha farm
 
 ```
 Ubuntu Executable (aarch64):
 
 ```bash
 
-./pulsar-ubuntu-aarch64-v0.6.3-alpha farm
+./pulsar-ubuntu-aarch64-v0.6.4-alpha farm
 
 ```
 

--- a/versioned_docs/version-latest/protocol/substrate-cli.mdx
+++ b/versioned_docs/version-latest/protocol/substrate-cli.mdx
@@ -220,7 +220,6 @@ We will be downloading two files for your respective operating system.
     --execution wasm `
     --blocks-pruning 256 `
     --state-pruning archive `
-    --no-private-ipv4 `
     --validator `
     --name "INSERT_YOUR_ID"
   ```
@@ -341,7 +340,6 @@ We will be downloading two files for your respective operating system.
     --execution wasm \
     --blocks-pruning 256 \
     --state-pruning archive \
-    --no-private-ipv4 \
     --validator \
     --name "INSERT_YOUR_ID"
   ```
@@ -493,7 +491,6 @@ We will be downloading two files for your respective operating system.
       --execution wasm \
       --blocks-pruning 256 \
       --state-pruning archive \
-      --no-private-ipv4 \
       --validator \
       --name "INSERT_YOUR_ID"
   ```


### PR DESCRIPTION
- Updates Pulsar from `v0.6.3-alpha` to `v0.6.4-alpha`
- Removes `--no-private-ipv4` command

Do Not Merge Until The following

- [x] https://github.com/subspace/pulsar/pull/253 Merged
- [x] https://github.com/subspace/pulsar/actions/workflows/release.yml latest `v0.6.4-alpha` action is complete