### PR TITLE
Update index.jsx

### DIFF
--- a/src/components/DockerFileGenerator/index.jsx
+++ b/src/components/DockerFileGenerator/index.jsx
@@ -96,6 +96,13 @@ function DockerFileGenerator() {
 
 	// Only generate the output if there are no validation errors
         if (Object.keys(validationErrors).length === 0) {
+            const volumesSection = (
+                (!formData.nodeData && !formData.farmerData) ? 
+                `volumes:
+          node-data:
+          farmer-data:` : ""
+            );
+
             const template = `\
 version: "3.7"
 services:
@@ -133,7 +140,7 @@ services:
         condition: service_healthy
     image: ghcr.io/subspace/farmer:${formData.snapshot}${formData.arch === "aarch64" ? "-aarch64" : ""}
     volumes:
-       - ${formData.farmerData ? formData.farmerData : "farmer-data"}:/var/subspace:rw
+      - ${formData.farmerData ? formData.farmerData : "farmer-data"}:/var/subspace:rw
     ports:
       - "0.0.0.0:${formData.farmerPort}:30533"
     restart: unless-stopped
@@ -145,7 +152,7 @@ services:
         "--reward-address", "${formData.rewardAddress}",
         "path=/var/subspace,size=${formData.plotSize}"
       ]
-volumes: ${formData.nodeData ? "" : "\n      node-data:"}${formData.farmerData ? "" : "\n      farmer-data:"}\
+    ${volumesSection}
             `;
             setOutput(template);
             setErrors({});


### PR DESCRIPTION
description:

1) I've added a conditional check to newly created volumesSection variable. It will generate the volumes section (at the end of the file) only if both formData.nodeData and formData.farmerData are not provided earlier. If either or both of these fields are specified earlier, the volumes section won't be generated. 
This change will ensure that the volumes section is included in the generated output only when it's necessary.

2) And there was 1 extra space (in line 37) in the generated docker-compose.yaml