### PR TITLE
Fix: incorrect subtitle number in guide

### DIFF
--- a/docs/protocol/substrate-cli.mdx
+++ b/docs/protocol/substrate-cli.mdx
@@ -101,7 +101,7 @@ For help refer to our forum post [How to setup Subwallet & a Polkadot.js Wallet]
 - *make sure to follow the Bonus section of the bottom of the post above.*
 
 
-### D. Required ports
+### C. Required ports
 
 Currently, a few ports need to be exposed for node to work properly.
 

--- a/versioned_docs/version-latest/protocol/substrate-cli.mdx
+++ b/versioned_docs/version-latest/protocol/substrate-cli.mdx
@@ -102,7 +102,7 @@ For help refer to our forum post [How to setup Subwallet & a Polkadot.js Wallet]
 - *make sure to follow the Bonus section of the bottom of the post above.*
 
 
-### D. Required ports
+### C. Required ports
 
 Currently, a few ports need to be exposed for node to work properly.
 


### PR DESCRIPTION
We use A, B, D now while it should be A, B, C.