### PR TITLE
Update Pulsar to `v0.6.14-alpha`

### DIFF
--- a/docs/protocol/pulsar.mdx
+++ b/docs/protocol/pulsar.mdx
@@ -151,7 +151,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-windows-x86_64-v2-v0.6.13-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-windows-x86_64-v2-v0.6.14-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -164,7 +164,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -198,7 +198,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-macos-x86_64-v0.6.13-alpha.zip">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-macos-x86_64-v0.6.14-alpha.zip">
       Mac CLI Executable (Intel)
     </Link>
   </div>
@@ -211,7 +211,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-macos-aarch64-v0.6.13-alpha.zip">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-macos-aarch64-v0.6.14-alpha.zip">
         Mac CLI Executable (Apple M Series)
     </Link>
   </div>
@@ -220,8 +220,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 4. Make the binary executable by running:
-    * `chmod +x pulsar-macos-x86_64-v0.6.13-alpha` (Intel Chip)
-    * `chmod +x pulsar-macos-aarch64-v0.6.13-alpha` (Apple M Series)
+    * `chmod +x pulsar-macos-x86_64-v0.6.14-alpha` (Intel Chip)
+    * `chmod +x pulsar-macos-aarch64-v0.6.14-alpha` (Apple M Series)
 
 :::warning
 Your Mac may not let you open/initialize the file because of unidentified developer restrictions. To resolve this, go to Settings-> Security&Privacy -> General -> Allow
@@ -248,7 +248,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-x86_64-v2-v0.6.13-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-x86_64-v2-v0.6.14-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -260,7 +260,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -274,7 +274,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-aarch64-v0.6.13-alpha">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-aarch64-v0.6.14-alpha">
         Ubuntu Executable (aarch64)
     </Link>
   </div>
@@ -282,8 +282,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 3. Make the binary executable by running:
-	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha` (Ubuntu)
-    * `chmod +x pulsar-ubuntu-aarch64-v0.6.13-alpha` (Ubuntu aarch64)
+	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha` (Ubuntu)
+    * `chmod +x pulsar-ubuntu-aarch64-v0.6.14-alpha` (Ubuntu aarch64)
 
 </TabItem>
 
@@ -299,7 +299,7 @@ To start we have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe init
+./pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe init
 ```
 
 :::note High RAM consumption
@@ -314,12 +314,12 @@ To start we have to initialize our Farmer, this can be done with:
 Intel Chip:
 
 ```shell-session
-./pulsar-macos-x86_64-v0.6.13-alpha  init
+./pulsar-macos-x86_64-v0.6.14-alpha  init
 ```
 Apple M Series:
 
 ```shell-session
-./pulsar-macos-aarch64-v0.6.13-alpha init
+./pulsar-macos-aarch64-v0.6.14-alpha init
 ```
 
 </TabItem>
@@ -328,12 +328,12 @@ Apple M Series:
 Ubuntu:
 
 ```shell-session
-./pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha  init
+./pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha  init
 ```
 Ubuntu Executable (aarch64):
 
 ```shell-session
-./pulsar-ubuntu-aarch64-v0.6.13-alpha  init
+./pulsar-ubuntu-aarch64-v0.6.14-alpha  init
 ```
 
 </TabItem>
@@ -421,7 +421,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe farm
+./pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe farm
 ```
 
 </TabItem>
@@ -431,12 +431,12 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 Intel Chip:
 
 ```shell-session
-./pulsar-macos-x86_64-v0.6.13-alpha farm
+./pulsar-macos-x86_64-v0.6.14-alpha farm
 ```
 Apple M1 Chip:
 
 ```shell-session
-./pulsar-macos-aarch64-v0.6.13-alpha farm
+./pulsar-macos-aarch64-v0.6.14-alpha farm
 ```
 
 </TabItem>
@@ -446,12 +446,12 @@ Apple M1 Chip:
 Ubuntu:
 
 ```shell-session
-./pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha farm
+./pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha farm
 ```
 Ubuntu Executable (aarch64):
 
 ```shell-session
-./pulsar-ubuntu-aarch64-v0.6.13-alpha farm
+./pulsar-ubuntu-aarch64-v0.6.14-alpha farm
 ```
 
 </TabItem>

--- a/versioned_docs/version-latest/protocol/pulsar.mdx
+++ b/versioned_docs/version-latest/protocol/pulsar.mdx
@@ -151,7 +151,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-windows-x86_64-v2-v0.6.13-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-windows-x86_64-v2-v0.6.14-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -164,7 +164,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe">
       Windows CLI Executable
     </Link>
   </div>
@@ -196,7 +196,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
       className="button button--secondary button"
-      to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-macos-x86_64-v0.6.13-alpha.zip">
+      to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-macos-x86_64-v0.6.14-alpha.zip">
       Mac CLI Executable (Intel)
     </Link>
   </div>
@@ -209,7 +209,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-macos-aarch64-v0.6.13-alpha.zip">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-macos-aarch64-v0.6.14-alpha.zip">
         Mac CLI Executable (Apple M Series)
     </Link>
   </div>
@@ -218,8 +218,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 2. Extract the `.zip` file.
 3. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 4. Make the binary executable by running:
-    * `chmod +x pulsar-macos-x86_64-v0.6.13-alpha` (Intel Chip)
-    * `chmod +x pulsar-macos-aarch64-v0.6.13-alpha` (Apple M Series)
+    * `chmod +x pulsar-macos-x86_64-v0.6.14-alpha` (Intel Chip)
+    * `chmod +x pulsar-macos-aarch64-v0.6.14-alpha` (Apple M Series)
 
 :::warning
 Your Mac may not let you open/initialize the file because of unidentified developer restrictions. To resolve this, go to Settings-> Security&Privacy -> General -> Allow
@@ -246,7 +246,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-x86_64-v2-v0.6.13-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-x86_64-v2-v0.6.14-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -258,7 +258,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
     <div className={styles.buttons}>
       <Link
           className="button button--secondary button"
-          to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha">
+          to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha">
           Ubuntu Executable
       </Link>
     </div>
@@ -272,7 +272,7 @@ Some older processors/VMs are no longer supported by official releases, but can 
   <div className={styles.buttons}>
     <Link
         className="button button--secondary button"
-        to="https://github.com/subspace/pulsar/releases/download/v0.6.13-alpha/pulsar-ubuntu-aarch64-v0.6.13-alpha">
+        to="https://github.com/subspace/pulsar/releases/download/v0.6.14-alpha/pulsar-ubuntu-aarch64-v0.6.14-alpha">
         Ubuntu Executable (aarch64)
     </Link>
   </div>
@@ -280,8 +280,8 @@ Some older processors/VMs are no longer supported by official releases, but can 
 
 2. Open Terminal, type `cd Downloads` (or `cd Your-File-Location`).
 3. Make the binary executable by running:
-	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha` (Ubuntu)
-    * `chmod +x pulsar-ubuntu-aarch64-v0.6.13-alpha` (Ubuntu aarch64)
+	* `chmod +x pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha` (Ubuntu)
+    * `chmod +x pulsar-ubuntu-aarch64-v0.6.14-alpha` (Ubuntu aarch64)
 
 </TabItem>
 
@@ -297,7 +297,7 @@ To start we have to initialize our Farmer, this can be done with:
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe init
+./pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe init
 ```
 
 :::note High RAM consumption
@@ -312,12 +312,12 @@ To start we have to initialize our Farmer, this can be done with:
 Intel Chip:
 
 ```shell-session
-./pulsar-macos-x86_64-v0.6.13-alpha  init
+./pulsar-macos-x86_64-v0.6.14-alpha  init
 ```
 Apple M Series:
 
 ```shell-session
-./pulsar-macos-aarch64-v0.6.13-alpha init
+./pulsar-macos-aarch64-v0.6.14-alpha init
 ```
 
 </TabItem>
@@ -326,12 +326,12 @@ Apple M Series:
 Ubuntu:
 
 ```shell-session
-./pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha  init
+./pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha  init
 ```
 Ubuntu Executable (aarch64):
 
 ```shell-session
-./pulsar-ubuntu-aarch64-v0.6.13-alpha  init
+./pulsar-ubuntu-aarch64-v0.6.14-alpha  init
 ```
 
 </TabItem>
@@ -419,7 +419,7 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 <TabItem value="windows" label="🖼️ Windows" default>
 
 ```powershell
-./pulsar-windows-x86_64-skylake-v0.6.13-alpha.exe farm
+./pulsar-windows-x86_64-skylake-v0.6.14-alpha.exe farm
 ```
 
 </TabItem>
@@ -429,12 +429,12 @@ To begin farming on the network, just run the `farm` command with the CLI like s
 Intel Chip:
 
 ```shell-session
-./pulsar-macos-x86_64-v0.6.13-alpha farm
+./pulsar-macos-x86_64-v0.6.14-alpha farm
 ```
 Apple M1 Chip:
 
 ```shell-session
-./pulsar-macos-aarch64-v0.6.13-alpha farm
+./pulsar-macos-aarch64-v0.6.14-alpha farm
 ```
 
 </TabItem>
@@ -444,12 +444,12 @@ Apple M1 Chip:
 Ubuntu:
 
 ```shell-session
-./pulsar-ubuntu-x86_64-skylake-v0.6.13-alpha farm
+./pulsar-ubuntu-x86_64-skylake-v0.6.14-alpha farm
 ```
 Ubuntu Executable (aarch64):
 
 ```shell-session
-./pulsar-ubuntu-aarch64-v0.6.13-alpha farm
+./pulsar-ubuntu-aarch64-v0.6.14-alpha farm
 ```
 
 </TabItem>


### PR DESCRIPTION
### Version Update Detected, please check the checkboxes below to acknowledge that merging this PR will notify the Discord community.
  
  
  - [x] Detected version change on Pulsar: v0.6.13-alpha -> v0.6.14-alpha
  
  
    
    This PR Updates Pulsar from `v0.6.13-alpha` to `v0.6.14-alpha`