### PR TITLE
Remove references to --execution command

### DIFF
--- a/docker-compose-auto.yml
+++ b/docker-compose-auto.yml
@@ -18,7 +18,6 @@ services:
     command: [
       "--chain", "gemini-2a",
       "--base-path", "/var/subspace",
-      "--execution", "wasm",
       "--state-pruning", "archive",
       "--port", "30333",
       "--rpc-cors", "all",

--- a/docs/protocol/substrate-cli.mdx
+++ b/docs/protocol/substrate-cli.mdx
@@ -219,7 +219,6 @@ We will be downloading two files for your respective operating system.
   # Copy all of the lines below, they are all part of the same command
   .\subspace-node-windows-x86_64-skylake-gemini-3f-2023-oct-06.exe `
     --chain gemini-3f `
-    --execution wasm `
     --blocks-pruning 256 `
     --state-pruning archive `
     --validator `
@@ -339,7 +338,6 @@ We will be downloading two files for your respective operating system.
   # Copy all of the lines below, they are all part of the same command
   ./subspace-node-macos-aarch64-gemini-3f-2023-oct-06 \
     --chain gemini-3f \
-    --execution wasm \
     --blocks-pruning 256 \
     --state-pruning archive \
     --validator \
@@ -490,7 +488,6 @@ We will be downloading two files for your respective operating system.
     # Copy all of the lines below, they are all part of the same command
     ./subspace-node-ubuntu-x86_64-skylake-gemini-3f-2023-oct-06 \
       --chain gemini-3f \
-      --execution wasm \
       --blocks-pruning 256 \
       --state-pruning archive \
       --validator \

--- a/src/components/DockerFileGenerator/index.jsx
+++ b/src/components/DockerFileGenerator/index.jsx
@@ -111,7 +111,6 @@ services:
       [
         "--chain", "${network}",
         "--base-path", "/var/subspace",
-        "--execution", "wasm",
         "--blocks-pruning", "256",
         "--state-pruning", "archive",
         "--port", "30333",

--- a/src/components/SystemdServiceFileGenerator/index.jsx
+++ b/src/components/SystemdServiceFileGenerator/index.jsx
@@ -82,7 +82,6 @@ After=network.target
 User=${formData.user}
 Group=${formData.user}
 ExecStart=${formData.nodeBinPath} \\
-          --execution wasm \\
           --name ${formData.nodeName} \\
           --base-path ${formData.nodeData} \\
           --state-pruning archive \\

--- a/versioned_docs/version-latest/protocol/substrate-cli.mdx
+++ b/versioned_docs/version-latest/protocol/substrate-cli.mdx
@@ -219,7 +219,6 @@ We will be downloading two files for your respective operating system.
   # Copy all of the lines below, they are all part of the same command
   .\subspace-node-windows-x86_64-skylake-gemini-3f-2023-oct-06.exe `
     --chain gemini-3f `
-    --execution wasm `
     --blocks-pruning 256 `
     --state-pruning archive `
     --validator `
@@ -339,7 +338,6 @@ We will be downloading two files for your respective operating system.
   # Copy all of the lines below, they are all part of the same command
   ./subspace-node-macos-aarch64-gemini-3f-2023-oct-06 \
     --chain gemini-3f \
-    --execution wasm \
     --blocks-pruning 256 \
     --state-pruning archive \
     --validator \
@@ -490,7 +488,6 @@ We will be downloading two files for your respective operating system.
     # Copy all of the lines below, they are all part of the same command
     ./subspace-node-ubuntu-x86_64-skylake-gemini-3f-2023-oct-06 \
       --chain gemini-3f \
-      --execution wasm \
       --blocks-pruning 256 \
       --state-pruning archive \
       --validator \


### PR DESCRIPTION
This PR removes the references to `--execution` command as per monorepo [PR 2163 ](https://github.com/subspace/subspace/pull/2163). 