### PR TITLE
Added `🌏Help Translate` CTA

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -163,6 +163,16 @@ const config = {
           {
             type: 'localeDropdown',
             position: 'right',
+            dropdownItemsAfter: [
+              {
+                type: 'html',
+                value: '<hr style="margin: 0.3rem 0;">',
+              },
+              {
+                href: 'https://docs.subspace.network/docs/community/translate',
+                label: '🌏 Help Translate',
+              },
+            ],
           },
           {
             href: 'https://github.com/subspace',


### PR DESCRIPTION
### Add 'Help Translate' Button to Language Selector

This PR introduces a `🌏 Help Translate` button at the end of the language selection dropdown.

**📷 Screenshot:**
![image](https://github.com/subspace/subspace-docs/assets/31865152/a58ed5b3-5d9b-4971-8889-60b5352b9f51)

**Please Note:** _The implementation deviates from typical Docusaurus internal linking due to conflicts with the language slug in the URL. While functional, it's a departure from standard programming practices._
