### PR TITLE
Remove `High RAM Consumption` from windows guides

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
@@ -2,12 +2,6 @@ import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
 ### Windows Specific Warnings:
-:::note High RAM consumption
-Operating systems, such as Windows, allocate memory for both visible tasks and behind-the-scenes processes. 
-While this memory can be readily freed when necessary, Windows occasionally may not display these allocations accurately due to certain system nuances.
-High RAM consumption should not be a cause for concern.
-:::
-
 :::caution  Windows No Output Bug
 If you face an error where the node outputs nothing and no error code is given it is likely you just need to install the latest Visual C++ Redistributable package [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 :::

--- a/docs/farming-&-staking/farming/pulsar/platforms/_windows.mdx
+++ b/docs/farming-&-staking/farming/pulsar/platforms/_windows.mdx
@@ -3,12 +3,6 @@ import styles from '@site/src/pages/index.module.css';
 
 
 ### Windows Specific Warnings:
-:::note High RAM consumption
-Operating systems, such as Windows, allocate memory for both visible tasks and behind-the-scenes processes. 
-While this memory can be readily freed when necessary, Windows occasionally may not display these allocations accurately due to certain system nuances.
-High RAM consumption should not be a cause for concern.
-:::
-
 :::caution  Windows No Output Bug
 If you face an error where the node outputs nothing and no error code is given it is likely you just need to install the latest Visual C++ Redistributable package [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 :::

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
@@ -2,12 +2,6 @@ import Link from '@docusaurus/Link';
 import styles from '@site/src/pages/index.module.css';
 
 ### Windows Specific Warnings:
-:::note High RAM consumption
-Operating systems, such as Windows, allocate memory for both visible tasks and behind-the-scenes processes. 
-While this memory can be readily freed when necessary, Windows occasionally may not display these allocations accurately due to certain system nuances.
-High RAM consumption should not be a cause for concern.
-:::
-
 :::caution  Windows No Output Bug
 If you face an error where the node outputs nothing and no error code is given it is likely you just need to install the latest Visual C++ Redistributable package [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 :::

--- a/versioned_docs/version-latest/farming-&-staking/farming/pulsar/platforms/_windows.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/pulsar/platforms/_windows.mdx
@@ -3,12 +3,6 @@ import styles from '@site/src/pages/index.module.css';
 
 
 ### Windows Specific Warnings:
-:::note High RAM consumption
-Operating systems, such as Windows, allocate memory for both visible tasks and behind-the-scenes processes. 
-While this memory can be readily freed when necessary, Windows occasionally may not display these allocations accurately due to certain system nuances.
-High RAM consumption should not be a cause for concern.
-:::
-
 :::caution  Windows No Output Bug
 If you face an error where the node outputs nothing and no error code is given it is likely you just need to install the latest Visual C++ Redistributable package [here](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170)
 :::


### PR DESCRIPTION
This PR Removes the high ram consumption warning in the windows guides for both pulsar and advanced cli. As per development team these issues have been resolved. 