### PR TITLE
Remove warning that Pulsar is not available for Gemini 3g

### DIFF
--- a/docs/farming-&-staking/farming/pulsar/pulsar-install.mdx
+++ b/docs/farming-&-staking/farming/pulsar/pulsar-install.mdx
@@ -17,10 +17,6 @@ import LinuxGuide from './platforms/_linux.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning
-Pulsar is not available for Gemini-3g as of this time. For the time being please us the [Advnaced CLI](../advanced-cli/cli-install) for Farming/Staking/Timekeeping
-:::
-
 :::tip Get Started with Pulsar
 [Pulsar](https://github.com/subspace/pulsar) (formerly Subspace CLI) is our recommended tool for farming on the Subspace Network. This ALPHA SOFTWARE is constantly evolving, and your feedback is invaluable in this process. To share your insights, please fill out this [feedback form](https://c6gxctjlh68.typeform.com/to/Ks4Y16Fo). For detailed guidance, follow the guide below and check out the [README on GitHub](https://github.com/subspace/pulsar/blob/main/README.md). Should you encounter any issues, feel free to file bug reports on our GitHub.
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/pulsar/pulsar-install.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/pulsar/pulsar-install.mdx
@@ -17,10 +17,6 @@ import LinuxGuide from './platforms/_linux.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::warning
-Pulsar is not available for Gemini-3g as of this time. For the time being please us the [Advnaced CLI](../advanced-cli/cli-install) for Farming/Staking/Timekeeping
-:::
-
 :::tip Get Started with Pulsar
 [Pulsar](https://github.com/subspace/pulsar) (formerly Subspace CLI) is our recommended tool for farming on the Subspace Network. This ALPHA SOFTWARE is constantly evolving, and your feedback is invaluable in this process. To share your insights, please fill out this [feedback form](https://c6gxctjlh68.typeform.com/to/Ks4Y16Fo). For detailed guidance, follow the guide below and check out the [README on GitHub](https://github.com/subspace/pulsar/blob/main/README.md). Should you encounter any issues, feel free to file bug reports on our GitHub.
 


### PR DESCRIPTION
Now that Pulsar is available for Gemini 3g it's time to remove the warning that tells farmers it is not ready.