### PR TITLE
Update Gemini 3g Nova RPC URL

### DIFF
--- a/docs/develop/nova/foundry_guide.md
+++ b/docs/develop/nova/foundry_guide.md
@@ -118,7 +118,7 @@ keywords:
     Environment variables can include database connection details, API keys, external resource URIs, or other configuration variables that might change depending on the environment in which the application is running. In our case, we would use it to point to our Core-EVM RPC url by setting
 
     ```bash
-    RPC_URL=https://domain-3.evm.gemini-3g.subspace.network/ws
+    RPC_URL=https://nova.gemini-3g.subspace.network/ws
     ```
 
     And then set a private key for the EVM-compatible wallet

--- a/docs/develop/nova/hardhat_guide.md
+++ b/docs/develop/nova/hardhat_guide.md
@@ -131,7 +131,7 @@ module.exports = {
 solidity: "0.8.19",
 networks: {
     subspace: {
-    url: "https://domain-3.evm.gemini-3g.subspace.network/ws",
+    url: "https://nova.gemini-3g.subspace.network/ws",
     accounts: ["private_key_to_your_account"]
     }
 }

--- a/docs/develop/nova/quick_start.md
+++ b/docs/develop/nova/quick_start.md
@@ -17,7 +17,7 @@ Subspace utilizes EVM (Ethereum Virtual Machine) so any tool available for Ether
 ---
 ```
 Network Name: Subspace EVM
-New RPC URL: https://domain-3.evm.gemini-3g.subspace.network/ws
+New RPC URL: https://nova.gemini-3g.subspace.network/ws
 Chain ID: 1002
 Currency Symbol: TSSC
 ```

--- a/docs/develop/nova/setting-up-metamask.md
+++ b/docs/develop/nova/setting-up-metamask.md
@@ -63,7 +63,7 @@ First, let’s set up a MetaMask wallet and then go over connecting it to the Su
 
   ```
   Network Name: Subspace EVM
-  New RPC URL: https://domain-3.evm.gemini-3g.subspace.network/ws
+  New RPC URL: https://nova.gemini-3g.subspace.network/ws
   Chain ID: 1002
   Currency Symbol: TSSC
   ```

--- a/versioned_docs/version-latest/develop/nova/foundry_guide.md
+++ b/versioned_docs/version-latest/develop/nova/foundry_guide.md
@@ -118,7 +118,7 @@ keywords:
     Environment variables can include database connection details, API keys, external resource URIs, or other configuration variables that might change depending on the environment in which the application is running. In our case, we would use it to point to our Core-EVM RPC url by setting
 
     ```bash
-    RPC_URL=https://domain-3.evm.gemini-3g.subspace.network/ws
+    RPC_URL=https://nova.gemini-3g.subspace.network/ws
     ```
 
     And then set a private key for the EVM-compatible wallet

--- a/versioned_docs/version-latest/develop/nova/hardhat_guide.md
+++ b/versioned_docs/version-latest/develop/nova/hardhat_guide.md
@@ -131,7 +131,7 @@ module.exports = {
 solidity: "0.8.19",
 networks: {
     subspace: {
-    url: "https://domain-3.evm.gemini-3g.subspace.network/ws",
+    url: "https://nova.gemini-3g.subspace.network/ws",
     accounts: ["private_key_to_your_account"]
     }
 }

--- a/versioned_docs/version-latest/develop/nova/quick_start.md
+++ b/versioned_docs/version-latest/develop/nova/quick_start.md
@@ -17,7 +17,7 @@ Subspace utilizes EVM (Ethereum Virtual Machine) so any tool available for Ether
 ---
 ```
 Network Name: Subspace EVM
-New RPC URL: https://domain-3.evm.gemini-3g.subspace.network/ws
+New RPC URL: https://nova.gemini-3g.subspace.network/ws
 Chain ID: 1002
 Currency Symbol: TSSC
 ```

--- a/versioned_docs/version-latest/develop/nova/setting-up-metamask.md
+++ b/versioned_docs/version-latest/develop/nova/setting-up-metamask.md
@@ -63,7 +63,7 @@ First, let’s set up a MetaMask wallet and then go over connecting it to the Su
 
   ```
   Network Name: Subspace EVM
-  New RPC URL: https://domain-3.evm.gemini-3g.subspace.network/ws
+  New RPC URL: https://nova.gemini-3g.subspace.network/ws
   Chain ID: 1002
   Currency Symbol: TSSC
   ```


### PR DESCRIPTION
Fix Gemini 3g Nova RPC URL. From https://domain-3.evm.gemini-3g.subspace.network/ws to https://nova.gemini-3g.subspace.network/ws.