### PR TITLE
Borrow storage section from space acres, move file-systems guide

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -65,15 +65,24 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### Storage
 
-HDDs are not supported and will never be. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+**HDDs are not supported and will never be**. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
 
-Node will require 100 GiB of good quality SSD. It doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
+**Node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
+reputable manufacturer with decent endurance is recommended.
 
-Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+**Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
+quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to
+disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
 
-RAID of any kind is pointless and can only harm performance and/or rewards. RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, reducing farming rewards for literally no benefit in exchange.
-
+**RAID of any kind is pointless and can only harm** performance and/or rewards. RAID0 will most likely make things
+slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other
+redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data
+on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, *reducing
+farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory, avoid **RAID** of any level.
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory.
+
+In order to disable **CoW**, run the command `chattr +C /your_farmer_directory/`.
+

--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -65,24 +65,24 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### Storage
 
-**HDDs are not supported and will never be**. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+**HDDs are not supported and will never be.** We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
 
-**Node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
+**The node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
 reputable manufacturer with decent endurance is recommended.
 
-**Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
+**The farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
 quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to
 disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
 
-**RAID of any kind is pointless and can only harm** performance and/or rewards. RAID0 will most likely make things
+**RAID of any kind is pointless and can only harm performance and/or rewards.** RAID0 will most likely make things
 slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other
-redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data
-on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, *reducing
+redundancy level is 100% pointless too since farms are stateless and can be removed if a disk breaks without losing data
+on other disks, it'll just make thing slower and reduce the effective capacity that can be used for farming, *reducing
 farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for farmer directory, or adjust the **recordsize**.
+You can use any file system with default settings, but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
 
 In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
 

--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -82,7 +82,8 @@ farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory.
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for farmer directory, or adjust the **recordsize**.
 
-In order to disable **CoW**, run the command `chattr +C /your_farmer_directory/`.
+In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
 
+In case of **ZFS**, you can try adjusting the **recordsize** by running `zfs set recordsize=128K tank/dataset`, or creating a separate **dataset** for the farmer with adjusted **recordsize** parameters.

--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -75,7 +75,7 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### File System
 
-You can use any file system with default settings, but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
+You can use any file system with default settings, we advise against their use for Subspace but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
 
 In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
 

--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -62,3 +62,18 @@ If you have a server with no firewall, there is nothing to be done, otherwise ma
 
 On the desktop side if you have a router in front of your computer, you'll need to forward TCP and UDP ports to the machine on which your node is running (how this is done varies from router to router, but there is always a feature like this, refer to [How to Forward Ports](../Additional-Guides/port-forwarding) for a more in-depth tutorial).
 If you're connected directly without any router, then again nothing needs to be done in such case.
+
+### Storage
+
+HDDs are not supported and will never be. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+
+Node will require 100 GiB of good quality SSD. It doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
+
+Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+
+RAID of any kind is pointless and can only harm performance and/or rewards. RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, reducing farming rewards for literally no benefit in exchange.
+
+
+### File System
+
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory, avoid **RAID** of any level.

--- a/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -67,18 +67,11 @@ If you're connected directly without any router, then again nothing needs to be 
 
 **HDDs are not supported and will never be.** We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
 
-**The node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
-reputable manufacturer with decent endurance is recommended.
+**The node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
 
-**The farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
-quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to
-disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+**The farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
 
-**RAID of any kind is pointless and can only harm performance and/or rewards.** RAID0 will most likely make things
-slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other
-redundancy level is 100% pointless too since farms are stateless and can be removed if a disk breaks without losing data
-on other disks, it'll just make thing slower and reduce the effective capacity that can be used for farming, *reducing
-farming rewards for literally no benefit in exchange*.
+**RAID of any kind is pointless and can only harm performance and/or rewards.** RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if a disk breaks without losing data on other disks, it'll just make thing slower and reduce the effective capacity that can be used for farming, *reducing farming rewards for literally no benefit in exchange*.
 
 ### File System
 

--- a/docs/participate/community_resources/_category_.json
+++ b/docs/participate/community_resources/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Community Resources",
+    "position": 1,
+    "link": {
+      "type": "generated-index",
+      "description": "Misc. community written guides for the Subspace Network"
+    }
+}

--- a/docs/participate/community_resources/file-systems.md
+++ b/docs/participate/community_resources/file-systems.md
@@ -1,6 +1,6 @@
 ---
 title: Partitioning and Mounting
-sidebar_position: 7
+sidebar_position: 1
 description: essential info to file systems. partitioning, and mounting.
 keywords:
     - Partition

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -65,24 +65,17 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### Storage
 
-**HDDs are not supported and will never be**. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+**HDDs are not supported and will never be.** We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
 
-**Node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
-reputable manufacturer with decent endurance is recommended.
+**The node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
 
-**Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
-quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to
-disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+**The farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
 
-**RAID of any kind is pointless and can only harm** performance and/or rewards. RAID0 will most likely make things
-slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other
-redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data
-on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, *reducing
-farming rewards for literally no benefit in exchange*.
+**RAID of any kind is pointless and can only harm performance and/or rewards.** RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if a disk breaks without losing data on other disks, it'll just make thing slower and reduce the effective capacity that can be used for farming, *reducing farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for farmer directory, or adjust the **recordsize**.
+You can use any file system with default settings, but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
 
 In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -82,6 +82,8 @@ farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory.
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for farmer directory, or adjust the **recordsize**.
 
-In order to disable **CoW**, run the command `chattr +C /your_farmer_directory/`.
+In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
+
+In case of **ZFS**, you can try adjusting the **recordsize** by running `zfs set recordsize=128K tank/dataset`, or creating a separate **dataset** for the farmer with adjusted **recordsize** parameters.

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -65,15 +65,23 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### Storage
 
-HDDs are not supported and will never be. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+**HDDs are not supported and will never be**. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
 
-Node will require 100 GiB of good quality SSD. It doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
+**Node will require 100 GiB of good quality SSD**. Doesn't have to be anything amazing, but something mid-range from a
+reputable manufacturer with decent endurance is recommended.
 
-Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+**Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken**, dedicating high
+quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to
+disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
 
-RAID of any kind is pointless and can only harm performance and/or rewards. RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, reducing farming rewards for literally no benefit in exchange.
-
+**RAID of any kind is pointless and can only harm** performance and/or rewards. RAID0 will most likely make things
+slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other
+redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data
+on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, *reducing
+farming rewards for literally no benefit in exchange*.
 
 ### File System
 
-You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory, avoid **RAID** of any level.
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory.
+
+In order to disable **CoW**, run the command `chattr +C /your_farmer_directory/`.

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -75,7 +75,7 @@ If you're connected directly without any router, then again nothing needs to be 
 
 ### File System
 
-You can use any file system with default settings, but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
+You can use any file system with default settings, we advise against their use for Subspace but in the case of CoW file systems like **ZFS** or **BTRFS** you need to disable **CoW** for the farmer directory, or adjust the **recordsize**.
 
 In order to disable **CoW** on **BTRFS**, run the command `chattr +C /your_farmer_directory/`.
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-prerequisites.mdx
@@ -62,3 +62,18 @@ If you have a server with no firewall, there is nothing to be done, otherwise ma
 
 On the desktop side if you have a router in front of your computer, you'll need to forward TCP and UDP ports to the machine on which your node is running (how this is done varies from router to router, but there is always a feature like this, refer to [How to Forward Ports](../Additional-Guides/port-forwarding) for a more in-depth tutorial).
 If you're connected directly without any router, then again nothing needs to be done in such case.
+
+### Storage
+
+HDDs are not supported and will never be. We don't recommended trying to use smart caching, tiered storage or other ways to accelerate it, you'll be 100% disappointed and just waste your time.
+
+Node will require 100 GiB of good quality SSD. It doesn't have to be anything amazing, but something mid-range from a reputable manufacturer with decent endurance is recommended.
+
+Farmer side can work with pretty much any SSD whatsoever that is not fake and not outright broken, dedicating high quality high endurance SSD is pointless unless you already have it for reasons unrelated to Subspace. Software writes to disk in near-perfect for SSD way, effectively doing write leveling if SSD is solely dedicated to farming.
+
+RAID of any kind is pointless and can only harm performance and/or rewards. RAID0 will most likely make things slower rather than faster (application benefits from knowing underlying hardware topology). RAID1 or any other redundancy level is 100% pointless too since farms are stateless and can be removed if disk breaks without losing data on other disks, it'll just make thing slower and reduce effective capacity that can be used for farming, reducing farming rewards for literally no benefit in exchange.
+
+
+### File System
+
+You can use any file system with default settings, but in case of CoW file systems like **ZFS** or **BTRFS** disable **CoW** for farmer directory, avoid **RAID** of any level.

--- a/versioned_docs/version-latest/participate/community_resources/_category_.json
+++ b/versioned_docs/version-latest/participate/community_resources/_category_.json
@@ -1,0 +1,8 @@
+{
+    "label": "Community Resources",
+    "position": 1,
+    "link": {
+      "type": "generated-index",
+      "description": "Misc. community written guides for the Subspace Network"
+    }
+}

--- a/versioned_docs/version-latest/participate/community_resources/file-systems.md
+++ b/versioned_docs/version-latest/participate/community_resources/file-systems.md
@@ -1,6 +1,6 @@
 ---
 title: Partitioning and Mounting
-sidebar_position: 7
+sidebar_position: 1
 description: essential info to file systems. partitioning, and mounting.
 keywords:
     - Partition


### PR DESCRIPTION
Following the Discord discussion, here are the proposed changes to the storage and file systems section of the documentation. 

1. Added **CoW** message.
2. Borrowed **Storage** section from SpaceAcres.
3. As an exception - moved the existing file-systems guide from **Learn** section to a newly created *Community Resources* section. I'm not suggesting promoting contributions to the new section since it will become a maintenance burden, but I believe we should make some exceptions for well-written guides. 

As always, open to any feedback. 