### PR TITLE
Revamp getting started section

### DIFF
--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -24,7 +24,7 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 ---
 ### **Become a farmer**
 
-**Farmers** on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain. A **farmer** plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
+**Farmers** on the Subspace Network are responsible for maintaining consensus, they do this by securing the **consensus chain**. A **farmer** plots pieces of **archival history** to disk, farms the created plot for block and vote rewards, and joins the DSN as a node for data retrieval.
 
 Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
@@ -33,7 +33,7 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 ### **Become a nominator**
 
-Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator, without having to become an operator or farmer themselves. **Nominators** are earning **staking** rewards, propotional to their **staking amount** and **nominators tax**.
+Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the nominator a pre-agreed **tax** on them.
 
 #### - [Start Nominating](../farming-&-staking/staking/)
 
@@ -45,20 +45,20 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 ### **Become a timekeeper**
 
-**Timekeepers** on the Subspace Network responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **Consensus Chain**.
+**Timekeepers** on the Subspace Network are responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **consensus chain**.
 
 #### - [Start timekeeping](../farming-&-staking/timekeeping)
 
-## 📖 Develop on the Subspace Network
+## 📖 Develop on The Subspace Network
 ---
 
 ### Utilize the EVM Domain
 
-The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
+The Subspace Network hosts an **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
 #### - [EVM Development](../develop/nova/intro)
 
 ### Utilize the Core Protocol
-The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to help with development within our network. 
+The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to assist and promote development on our network. 
 
 #### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)

--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -24,10 +24,9 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 ---
 ### **Become a farmer**
 
-Farmers on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain.
-A Farmer plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
+**Farmers** on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain. A **farmer** plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
 
-Choose one of the following methods to start farming on the Network (from easy to more complex):
+Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
 #### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
 #### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
@@ -55,7 +54,7 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 ### Utilize the EVM Domain
 
-The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your smart contracts. 
+The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
 #### - [EVM Development](../develop/nova/intro)
 

--- a/docs/learn/intro.md
+++ b/docs/learn/intro.md
@@ -20,16 +20,46 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 - [Whitepaper - *Summarized*](https://subspace.network/news/subspace-network-whitepaper)
 - [Whitepaper - *Full Length*](https://assets.website-files.com/61526a2af87a54e565b0ae92/617759c00edd0e3bd279aa29_Subspace_%20A%20solution%20to%20the%20farmer%27s%20dilemma.pdf)
 
-## 🤝 Participate on the Network
+## 🤝 Participate on the Subspace Network
 ---
-Our goal is to bring an extremely low barrier to entry for participating on consensus. You can get started as long as you meet the simple requirements mentioned below.
+### **Become a farmer**
 
+Farmers on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain.
+A Farmer plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
 
-### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
+Choose one of the following methods to start farming on the Network (from easy to more complex):
 
-## 📖 Develop on Subspace Network
+#### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
+#### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
+
+### **Become a nominator**
+
+Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator, without having to become an operator or farmer themselves. **Nominators** are earning **staking** rewards, propotional to their **staking amount** and **nominators tax**.
+
+#### - [Start Nominating](../farming-&-staking/staking/)
+
+### **Become an operator**
+
+**Operators** are responsible for validating and executing transactions, producing execution receipts, applying state transitions and earn rewards for their work.
+
+#### - [Start an Opeator node](../farming-&-staking/staking/operators/register-operator)
+
+### **Become a timekeeper**
+
+**Timekeepers** on the Subspace Network responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **Consensus Chain**.
+
+#### - [Start timekeeping](../farming-&-staking/timekeeping)
+
+## 📖 Develop on the Subspace Network
 ---
 
+### Utilize the EVM Domain
+
+The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your smart contracts. 
+
+#### - [EVM Development](../develop/nova/intro)
+
+### Utilize the Core Protocol
 The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to help with development within our network. 
 
-### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)
+#### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -24,7 +24,7 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 ---
 ### **Become a farmer**
 
-**Farmers** on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain. A **farmer** plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
+**Farmers** on the Subspace Network are responsible for maintaining consensus, they do this by securing the **consensus chain**. A **farmer** plots pieces of **archival history** to disk, farms the created plot for block and vote rewards, and joins the DSN as a node for data retrieval.
 
 Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
@@ -33,7 +33,7 @@ Choose one of the following methods to **start farming** on the Network (from ea
 
 ### **Become a nominator**
 
-Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator, without having to become an operator or farmer themselves. **Nominators** are earning **staking** rewards, propotional to their **staking amount** and **nominators tax**.
+Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator without having to become an operator or farmer themselves. **Nominators** earn **staking** rewards, proportional to their **staking amount** and pay the nominator a pre-agreed **tax** on them.
 
 #### - [Start Nominating](../farming-&-staking/staking/)
 
@@ -45,20 +45,20 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 ### **Become a timekeeper**
 
-**Timekeepers** on the Subspace Network responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **Consensus Chain**.
+**Timekeepers** on the Subspace Network are responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **consensus chain**.
 
 #### - [Start timekeeping](../farming-&-staking/timekeeping)
 
-## 📖 Develop on the Subspace Network
+## 📖 Develop on The Subspace Network
 ---
 
 ### Utilize the EVM Domain
 
-The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
+The Subspace Network hosts an **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
 #### - [EVM Development](../develop/nova/intro)
 
 ### Utilize the Core Protocol
-The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to help with development within our network. 
+The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to assist and promote development on our network. 
 
 #### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -24,10 +24,9 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 ---
 ### **Become a farmer**
 
-Farmers on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain.
-A Farmer plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
+**Farmers** on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain. A **farmer** plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
 
-Choose one of the following methods to start farming on the Network (from easy to more complex):
+Choose one of the following methods to **start farming** on the Network (from easy to more complex):
 
 #### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
 #### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
@@ -55,7 +54,7 @@ Farmers can nominate **operators** and back them with their tokens, increasing t
 
 ### Utilize the EVM Domain
 
-The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your smart contracts. 
+The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your **smart contracts.** 
 
 #### - [EVM Development](../develop/nova/intro)
 

--- a/versioned_docs/version-latest/learn/intro.md
+++ b/versioned_docs/version-latest/learn/intro.md
@@ -20,16 +20,46 @@ The Subspace Network is an ambitious layer zero protocol which is the first scal
 - [Whitepaper - *Summarized*](https://subspace.network/news/subspace-network-whitepaper)
 - [Whitepaper - *Full Length*](https://assets.website-files.com/61526a2af87a54e565b0ae92/617759c00edd0e3bd279aa29_Subspace_%20A%20solution%20to%20the%20farmer%27s%20dilemma.pdf)
 
-## 🤝 Participate on the Network
+## 🤝 Participate on the Subspace Network
 ---
-Our goal is to bring an extremely low barrier to entry for participating on consensus. You can get started as long as you meet the simple requirements mentioned below.
+### **Become a farmer**
 
+Farmers on the Subspace Network are responsible for maintaining consensus, or safety of the Consensus Chain.
+A Farmer plots pieces of Archival History to disk, farms the created plot for block rewards, and joins the DSN as a node for data retrieval.
 
-### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
+Choose one of the following methods to start farming on the Network (from easy to more complex):
 
-## 📖 Develop on Subspace Network
+#### - [Start Farming with Pulsar](../farming-&-staking/farming/pulsar/pulsar-prerequisites)
+#### - [Start Farming with Advanced CLI](../farming-&-staking/farming/advanced-cli/cli-install)
+
+### **Become a nominator**
+
+Farmers can nominate **operators** and back them with their tokens, increasing their stake and chance of being elected as slot leaders. Generally speaking, any SSC token holder can stake their tokens by **nominating** a domain operator, without having to become an operator or farmer themselves. **Nominators** are earning **staking** rewards, propotional to their **staking amount** and **nominators tax**.
+
+#### - [Start Nominating](../farming-&-staking/staking/)
+
+### **Become an operator**
+
+**Operators** are responsible for validating and executing transactions, producing execution receipts, applying state transitions and earn rewards for their work.
+
+#### - [Start an Opeator node](../farming-&-staking/staking/operators/register-operator)
+
+### **Become a timekeeper**
+
+**Timekeepers** on the Subspace Network responsible for running the **Proof-of-Time chain** and maintaining the randomness beacon for the **Consensus Chain**.
+
+#### - [Start timekeeping](../farming-&-staking/timekeeping)
+
+## 📖 Develop on the Subspace Network
 ---
 
+### Utilize the EVM Domain
+
+The Subspace Network has a running **EVM (Ethereum Virtual Machine)**, that allows you to deploy your smart contracts. 
+
+#### - [EVM Development](../develop/nova/intro)
+
+### Utilize the Core Protocol
 The Subspace Network aims to provide an amazing developer experience to anyone who wishes to build on top of the protocol. As such we have started working on a variety of tools to help with development within our network. 
 
-### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)
+#### - [Core Protocol Development](https://github.com/subspace/subspace/blob/main/docs/development.md)


### PR DESCRIPTION
This PR revamps the **Getting Started** section, it separates and directs users to:
1. Farming with Pulsar
2. Farming with AdvancedCLI
3. Becoming a nominator
4. Becoming an operator
5. Becoming a timekeeper

And for developers:
1. Utilize EVM domain
2. Core protocol development

I wonder if we should add a link to SpaceAcres among the available farming options, wdyt? Is there anything else worth adding, in your opinion? 
