### PR TITLE
Ensure all latest releases pointing using gemini 3g flags

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-tips.mdx
@@ -74,7 +74,6 @@ If you were running a node previously, and want to switch to a new network, plea
 # Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases
 ./NODE_FILE_NAME wipe NODE_DATA_PATH
 ```
-It does not matter if the node/farmer executable is the previous one or from the new snapshot, both will work.
 
 Now follow the installation guide from the beginning.
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-tips.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/cli-tips.mdx
@@ -65,16 +65,16 @@ In general you should be able to download the latest release, and re-start the N
 
 There are some cases where version updates will cause issue with your Node & Farmer and you may have to wipe your node, typically when errors occur. If you have any issues you can always check our [Forums](https://forums.subspace.network) and hop in our [Discord](https://discord.gg/subspace-network) Server to ask for help.
 
-### Wipe
+### Wipe & Purge
 
 If you were running a node previously, and want to switch to a new network, please perform these steps and then follow the guide again:
 ```bash
 # Replace `FARMER_FILE_NAME` with the name of the farmer file you downloaded from releases
 ./FARMER_FILE_NAME wipe PATH_TO_FARM
 # Replace `NODE_FILE_NAME` with the name of the node file you downloaded from releases
-./NODE_FILE_NAME wipe NODE_DATA_PATH
+./NODE_FILE_NAME purge-chain --chain gemini-3g
 ```
-It does not matter if the node/farmer executable is the previous one or from the new snapshot, both will work.
+It does not matter if the node/farmer executable is the previous one or from the new snapshot, both will work :)
 
 Now follow the installation guide from the beginning.
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
@@ -94,16 +94,12 @@ import styles from '@site/src/pages/index.module.css';
   # Replace `INSERT_YOUR_ID` with a nickname you choose
   # Copy all of the lines below, they are all part of the same command
   ./subspace-node-ubuntu-x86_64-skylake-gemini-3g-2024-jan-31 \
-    --chain gemini-3h \
+    --chain gemini-3g \
     --blocks-pruning 256 \
     --state-pruning archive-canonical \
     --farmer \
     --name "INSERT_YOUR_ID"
 ```
-
-:::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
-:::
 
 4. You should see something similar in the terminal:
 ```

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
@@ -64,16 +64,12 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 # Replace `INSERT_YOUR_ID` with a nickname you choose
 # Copy all of the lines below, they are all part of the same command
 ./subspace-node-macos-aarch64-gemini-3g-2024-jan-31 \
-  --chain gemini-3h \
+  --chain gemini-3g \
   --blocks-pruning 256 \
   --state-pruning archive-canonical \
   --farmer \
   --name "INSERT_YOUR_ID"
 ```
-
-:::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
-:::
 
 4. You should see something similar in the terminal:
 ```

--- a/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
@@ -60,16 +60,12 @@ This is because the application is trying to access the internet. This is expect
 # Replace `INSERT_YOUR_ID` with a nickname you choose
 # Copy all of the lines below, they are all part of the same command
 .\subspace-node-windows-x86_64-skylake-gemini-3g-2024-jan-31.exe `
-  --chain gemini-3h `
+  --chain gemini-3g `
   --blocks-pruning 256 `
   --state-pruning archive-canonical `
   --farmer `
   --name "INSERT_YOUR_ID"
 ```
-
-:::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
-:::
   
 4. You should see something similar in the terminal:
 ```text


### PR DESCRIPTION
For consistency - all "latest" releases should be pointing to `gemini-3g` chain, use another release and old `purge-chain` commands for wiping. 