### PR TITLE
Update _systemd.mdx - Fixing incorrect reference to /root

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
@@ -115,11 +115,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
 		</CodeBlock>
     </details>
     <details>
@@ -128,11 +128,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
 		</CodeBlock>
     </details>
 </details>
@@ -143,11 +143,11 @@ Download the Executable Files, using the appropriate commands:
     </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-aarch64-gemini-3g-2023-sep-25
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-aarch64-gemini-3g-2023-sep-25
 		</CodeBlock>
 </details>
 


### PR DESCRIPTION
In the instructions for setting up the service as a user rather than root, all the wget statements were still directed to download the files into /root/.local/bin rather than ~/.local/bin