### PR TITLE
Update _systemd.mdx - fixes and updates

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_systemd.mdx
@@ -29,11 +29,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-x86_64-v2-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-x86_64-v2-gemini-3h-2024-feb-05
 		</CodeBlock>
     </details>
     <details>
@@ -42,11 +42,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-x86_64-skylake-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-x86_64-skylake-gemini-3h-2024-feb-05
 		</CodeBlock>
     </details>
 </details>
@@ -57,11 +57,11 @@ Download the Executable Files, using the appropriate commands:
     </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-aarch64-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-aarch64-gemini-3h-2024-feb-05
 		</CodeBlock>
 </details>
 
@@ -115,11 +115,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-x86_64-v2-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-v2-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-x86_64-v2-gemini-3h-2024-feb-05
 		</CodeBlock>
     </details>
     <details>
@@ -128,11 +128,11 @@ Download the Executable Files, using the appropriate commands:
         </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-x86_64-skylake-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-x86_64-skylake-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-x86_64-skylake-gemini-3h-2024-feb-05
 		</CodeBlock>
     </details>
 </details>
@@ -143,11 +143,11 @@ Download the Executable Files, using the appropriate commands:
     </summary>
 		Node:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-node-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-node https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-node-ubuntu-aarch64-gemini-3h-2024-feb-05
 		</CodeBlock>
 		Farmer:
 		<CodeBlock language="shell-session">
-		wget -O /root/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3g-2023-sep-25/subspace-farmer-ubuntu-aarch64-gemini-3g-2023-sep-25
+		wget -O ~/.local/bin/subspace-farmer https://github.com/subspace/subspace/releases/download/gemini-3h-2024-feb-05/subspace-farmer-ubuntu-aarch64-gemini-3h-2024-feb-05
 		</CodeBlock>
 </details>
 


### PR DESCRIPTION
Corrected references to /root/.local/bin to be ~/.local/bin in the section for installing service as a user.  Also updated the paths in all of the example references to the latest 3h 20240205 version (from 3g 20230925 version)