### PR TITLE
Remove Pulsar recommendation, update advanced-cli note

### DIFF
--- a/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/cli-install.mdx
@@ -19,10 +19,6 @@ import SourcePage from './platforms/_source.mdx';
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-:::caution Advanced Usage
-[Pulsar](https://github.com/subspace/pulsar) (previously Simple CLI or Subspace CLI) is the recommended way to farm on the Subspace Network. Follow the guide below to get started or check out the project [README on GitHub](https://github.com/subspace/pulsar/blob/main/README.md).
-:::
-
 :::tip 
 [Releases](https://github.com/subspace/subspace/releases) section on our GitHub is the best place to get fresh releases of binaries and check out the source code.
 :::

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_linux.mdx
@@ -99,7 +99,7 @@ import styles from '@site/src/pages/index.module.css';
 ```
 
 :::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
+Using **run**, setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
 :::
 
 4. You should see something similar in the terminal:

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_macos.mdx
@@ -72,7 +72,7 @@ After this, simply repeat the step you prompted for (step 4 or 6). This time, cl
 ```
 
 :::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
+Using **run**, setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h.
 :::
 
 4. You should see something similar in the terminal:

--- a/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
+++ b/docs/farming-&-staking/farming/advanced-cli/platforms/_windows.mdx
@@ -68,7 +68,7 @@ This is because the application is trying to access the internet. This is expect
 ```
 
 :::note
-Setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h. 
+Using **run**, setting **--base-path** and specifying **--chain** became mandatory starting with Gemini 3h.
 :::
   
 4. You should see something similar in the terminal:


### PR DESCRIPTION
As per user feedback, we can make the important note for the installation section better. 
Additionally, a message redirecting users to Pulsar needs to be removed. 