### PR TITLE
Update Latest docker file

### DIFF
--- a/src/components/DockerFileGenerator/DockerFileLatest.jsx
+++ b/src/components/DockerFileGenerator/DockerFileLatest.jsx
@@ -20,7 +20,7 @@ function DockerFileGeneratorLatest() {
     });
 
     // Predefine the actual network
-    const network = 'gemini-3g';
+    const network = 'gemini-3h';
     
     // State for the generated output (docker compose content)
     const [output, setOutput] = useState('');
@@ -111,18 +111,16 @@ services:
     restart: unless-stopped
     command:
       [
+        "run",
         "--chain", "${network}",
         "--base-path", "/var/subspace",
-        "--blocks-pruning", "256",
-        "--state-pruning", "archive-canonical",
-        "--port", "30333",
+        "--listen-on", "/ip4/0.0.0.0/tcp/30333",
         "--dsn-listen-on", "/ip4/0.0.0.0/udp/30433/quic-v1",
         "--dsn-listen-on", "/ip4/0.0.0.0/tcp/30433",
         "--rpc-cors", "all",
         "--rpc-methods", "unsafe",
-        "--rpc-external",
-        "--no-private-ipv4",
-        "--validator",
+        "--rpc-listen-on", "0.0.0.0:9944",
+        "--farmer",
         "--name", "${formData.nodeName}"
       ]
     healthcheck:


### PR DESCRIPTION
Since fetching the releases is managed by matching on the network (gemini-3h) and not the github release label (pre-release, latest), we can safely update the docker file. The list of available versions should correspond to Gemini 3h releases, but please do test it. 