### PR TITLE
Add homebrew installation tip for pulsar

### DIFF
--- a/docs/farming-&-staking/farming/pulsar/platforms/_macos.mdx
+++ b/docs/farming-&-staking/farming/pulsar/platforms/_macos.mdx
@@ -27,7 +27,9 @@ Your Mac may not let you open/initialize the file because of unidentified develo
   </Link>
 </div>
 
-
+:::tip
+If you have the [homebrew package manager installed](https://brew.sh/), you can get Pulsar by running `brew tap subspace/homebrew-pulsar` and `brew install pulsar`.
+:::
 
 ## Step 2: Initialize Pulsar
 ---

--- a/versioned_docs/version-latest/farming-&-staking/farming/pulsar/platforms/_macos.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/pulsar/platforms/_macos.mdx
@@ -27,7 +27,9 @@ Your Mac may not let you open/initialize the file because of unidentified develo
   </Link>
 </div>
 
-
+:::tip
+If you have the [homebrew package manager installed](https://brew.sh/), you can get Pulsar by running `brew tap subspace/homebrew-pulsar` and `brew install pulsar`.
+:::
 
 ## Step 2: Initialize Pulsar
 ---


### PR DESCRIPTION
Pulsar installation is now possible through homebrew: https://github.com/subspace/pulsar/pull/297
I didn't want it to be confusing for users, as some might not know what the homebrew is, so I just added the information as a tip for the MacOS Pulsar section. What do you think? 