### PR TITLE
Fix SubWallet RPC endpoint formatting

### DIFF
--- a/docs/farming-&-staking/wallets/subwallet.md
+++ b/docs/farming-&-staking/wallets/subwallet.md
@@ -72,11 +72,11 @@ Sometimes you won't see the network you would like to connect to in a list of av
 This also can be helpful for in-development networks such as the Subspace Network as we have regularly changing RPC endpoints and versions of testnets, and soon various domains. Below you will find a simple guide on how to add these new networks. Additionally we will try and keep an updated list of active RPC endpoints below for development.
 
 :::info RPC Endpoints
-- **Gemini 3d Endpoint:** `wss://rpc.gemini-3d.subspace.network/ws`
-- **Gemini 3e Endpoint:** `wss://rpc.gemini-3e.subspace.network/ws`
-- **Gemini 3f Endpoint:** `wss://rpc-1.gemini-3f.subspace.network/ws`
-- **Gemini 3g Endpoint:** `wss://rpc-1.gemini-3g.subspace.network/ws`
-- **Gemini 3h Endpoint:** `wss://rpc-1.gemini-3h.subspace.network/ws`
+**Gemini 3d Endpoint:** `wss://rpc.gemini-3d.subspace.network/ws`
+**Gemini 3e Endpoint:** `wss://rpc.gemini-3e.subspace.network/ws`
+**Gemini 3f Endpoint:** `wss://rpc-1.gemini-3f.subspace.network/ws`
+**Gemini 3g Endpoint:** `wss://rpc-1.gemini-3g.subspace.network/ws`
+**Gemini 3h Endpoint:** `wss://rpc-1.gemini-3h.subspace.network/ws`
 :::
 
 1. Open SubWallet, Select the 3 Line menu in the top left of the wallet.

--- a/versioned_docs/version-latest/farming-&-staking/wallets/subwallet.md
+++ b/versioned_docs/version-latest/farming-&-staking/wallets/subwallet.md
@@ -72,11 +72,11 @@ Sometimes you won't see the network you would like to connect to in a list of av
 This also can be helpful for in-development networks such as the Subspace Network as we have regularly changing RPC endpoints and versions of testnets, and soon various domains. Below you will find a simple guide on how to add these new networks. Additionally we will try and keep an updated list of active RPC endpoints below for development.
 
 :::info RPC Endpoints
-- **Gemini 3d Endpoint:** `wss://rpc.gemini-3d.subspace.network/ws`
-- **Gemini 3e Endpoint:** `wss://rpc.gemini-3e.subspace.network/ws`
-- **Gemini 3f Endpoint:** `wss://rpc-1.gemini-3f.subspace.network/ws`
-- **Gemini 3g Endpoint:** `wss://rpc-1.gemini-3g.subspace.network/ws`
-- **Gemini 3h Endpoint:** `wss://rpc-1.gemini-3h.subspace.network/ws`
+**Gemini 3d Endpoint:** `wss://rpc.gemini-3d.subspace.network/ws`
+**Gemini 3e Endpoint:** `wss://rpc.gemini-3e.subspace.network/ws`
+**Gemini 3f Endpoint:** `wss://rpc-1.gemini-3f.subspace.network/ws`
+**Gemini 3g Endpoint:** `wss://rpc-1.gemini-3g.subspace.network/ws`
+**Gemini 3h Endpoint:** `wss://rpc-1.gemini-3h.subspace.network/ws`
 :::
 
 1. Open SubWallet, Select the 3 Line menu in the top left of the wallet.


### PR DESCRIPTION
A similar issue has been traced back to the use of bullets in a `caution` block. This PR removes bullets from the  RPC endpoints `info` block. Fingers crossed as we don't see the issue in the Netlify preview. It appears to be the combination of Docusaurus and the CrowdIn integration that triggers the bad formatting.

Part of the conversation from @EmilFattakhov recorded for posterity below.

> This indentation in a compiled version (you won't see it in a usual advanced-cli page, this page lives under /i18n/en/current/farming-staking/advanved-cli/cli-install.mdx) is what causes the error, and, thanks to JS, the message itself is very cryptic.
>
> ![image](https://github.com/subspace/subspace-docs/assets/11335994/312b251b-1cd8-4269-a6f4-914bb7fec223)
>
>The cause of it in an incorrect handling of `-` in the note, somehow after compilation `-` becomes `*` and prevents the node block from rendering properly.
>
> The solution that worked for me locally is to remove `-` before Skylake and Legacy (you can keep them in bold).
>
> Here is a compiled version of that file after the `-` was removed:
>
> ![image](https://github.com/subspace/subspace-docs/assets/11335994/54b726a3-db6c-4acc-8468-8804450370c6)
