### PR TITLE
Update space-acres-0.1.3 -> space-acres-0.1.5

### DIFF
--- a/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -4,21 +4,21 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres-0.1.3-x86_64.msi"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres-0.1.5-x86_64.msi"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Windows Installer</span>
     <span style={{ fontSize: '14px' }}>(.MSI)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres_0.1.3-1_amd64.deb"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres_0.1.5-1_amd64.deb"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
     <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres-0.1.3-x86_64.AppImage"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres-0.1.5-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>

--- a/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -4,21 +4,21 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres-0.1.3-x86_64.msi"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres-0.1.5-x86_64.msi"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Windows Installer</span>
     <span style={{ fontSize: '14px' }}>(.MSI)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres_0.1.3-1_amd64.deb"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres_0.1.5-1_amd64.deb"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
     <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.3/space-acres-0.1.3-x86_64.AppImage"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.5/space-acres-0.1.5-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>


### PR DESCRIPTION
In this release:

Node sync, piece cache sync and plotting all happening concurrently
Unplotted space is used for caching purposes
Thanks to all of the above Space Acres is able to share its downloading and caching functionality between node and farmer components, accelerating everything, especially for small farmers
Minor performance improvements
Plotting threads are de-prioritized, which may decrease plotting performance slightly, but should improve farming performance and allow more comfortable use of computer for other purposes
Most of these changes are from upcoming upstream release
Memory usage improvements for plot cache introduced in the last release on Windows (0.1.4)
Plot cache disabled on large farms with 2T+ of unplotted space on Windows since regular piece cache is already pretty large and Windows hangs for too long otherwise