### PR TITLE
Update docusaurus.config.js to fix dev docs link

### DIFF
--- a/docs/develop/nova/_category_.json
+++ b/docs/develop/nova/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Develop on Nova EVM ",
+  "label": "Develop on Nova EVM",
   "position": 3,
   "link": {
     "type": "generated-index",

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -65,8 +65,8 @@ const config = {
             from: '/docs/community/contribute/',
           },
           {
-            to: '/docs/category/develop-on-nova-evm-',
-            from: ['/docs/category/developer-documentation/','/docs/developers/intro']
+            to: '/docs/category/develop-on-nova-evm',
+            from: ['/docs/category/developer-documentation/','/docs/developers/intro/']
           },
           {
             to: "/docs/category/operators-and-nominators",
@@ -102,7 +102,7 @@ const config = {
             from: "/docs/pre-release/community/contribute/",
           },
           {
-            to: "/docs/pre-release/category/develop-on-nova-evm-",
+            to: "/docs/pre-release/category/develop-on-nova-evm",
             from: "/docs/pre-release/category/developer-documentation/",
           },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -66,7 +66,7 @@ const config = {
           },
           {
             to: '/docs/category/develop-on-nova-evm-',
-            from: '/docs/category/developer-documentation/',
+            from: ['/docs/category/developer-documentation/','/docs/developers/intro']
           },
           {
             to: "/docs/category/operators-and-nominators",
@@ -95,10 +95,6 @@ const config = {
           {
             to: "/docs/farming-&-staking/staking/operators/register-operator",
             from: "/docs/farming-&-staking/staking/operators"
-          },
-          {
-            to: "/docs/category/develop-on-nova-evm-",
-            from: "/docs/developers/intro",
           },
           //Pre-Release Links
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,6 +96,10 @@ const config = {
             to: "/docs/farming-&-staking/staking/operators/register-operator",
             from: "/docs/farming-&-staking/staking/operators"
           },
+          {
+            to: "/docs/category/develop-on-nova-evm-",
+            from: "/docs/developers/intro",
+          },
           //Pre-Release Links
           {
             to: "/docs/pre-release/participate/contribute",

--- a/versioned_docs/version-latest/develop/nova/_category_.json
+++ b/versioned_docs/version-latest/develop/nova/_category_.json
@@ -1,5 +1,5 @@
 {
-  "label": "Develop on Nova EVM ",
+  "label": "Develop on Nova EVM",
   "position": 3,
   "link": {
     "type": "generated-index",


### PR DESCRIPTION
Fixed broken link  from: "/docs/developers/intro",

to: "/docs/category/develop-on-nova-evm-",
           