### PR TITLE
Update Space Acres `v0.1.16` -> `v0.1.17`

### DIFF
--- a/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -4,21 +4,21 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres-0.1.16-x86_64.msi"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres-0.1.17-x86_64.msi"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Windows Installer</span>
     <span style={{ fontSize: '14px' }}>(.MSI)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres_0.1.16-1_amd64.deb"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres_0.1.17-1_amd64.deb"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
     <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres-0.1.16-x86_64.AppImage"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres-0.1.17-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>

--- a/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -4,21 +4,21 @@ import styles from '@site/src/pages/index.module.css';
 <div className={`${styles.buttons} ${styles.flexContainer}`}>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres-0.1.16-x86_64.msi"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres-0.1.17-x86_64.msi"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Windows Installer</span>
     <span style={{ fontSize: '14px' }}>(.MSI)</span>
   </Link>
   <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres_0.1.16-1_amd64.deb"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres_0.1.17-1_amd64.deb"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
     <Link
     className="button button--secondary"
-    to="https://github.com/subspace/space-acres/releases/download/0.1.16/space-acres-0.1.16-x86_64.AppImage"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.17/space-acres-0.1.17-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>


### PR DESCRIPTION
In line with release of https://github.com/subspace/space-acres/releases/tag/0.1.17.