### PR TITLE
Drop Polish and Portuguese languages localization support

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale,
-    locales: ["ar", "en", "fr", "de", "id", "it", "ja", "uk", "zh", "pt", "ru", "es", "tr"],
+    locales: ["ar", "en", "fr", "de", "id", "it", "ja", "uk", "zh", "ru", "es", "tr"],
   },
   plugins: [
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -44,7 +44,7 @@ const config = {
   // to replace "en" with "zh-Hans".
   i18n: {
     defaultLocale,
-    locales: ["ar", "en", "fr", "de", "id", "it", "ja", "uk", "zh", "pl", "pt", "ru", "es", "tr"],
+    locales: ["ar", "en", "fr", "de", "id", "it", "ja", "uk", "zh", "pt", "ru", "es", "tr"],
   },
   plugins: [
     [


### PR DESCRIPTION
FYI Ryan, here is the corresponding change we need to make that I was talking about.

Each time we add or drop the language on CrowdIn we need to update the docusaurus config, otherwise we'd be getting a compilation error. 

cc @randywessels