### PR TITLE
Add note to elaborate on verified farmer role on Astral

### DIFF
--- a/docs/farming-&-staking/farming/additional-guides/verify-farmer.md
+++ b/docs/farming-&-staking/farming/additional-guides/verify-farmer.md
@@ -24,7 +24,7 @@ You can track your farmer through the [Astral Block Explorer.](https://explorer.
 2. Sign into your wallet through Subwallet or Polkadot.
 ![Select Wallet](/img/doc-imgs/verify-farmer/select-wallet.png)
 
-3. Find the new **Get your Farmer role on Discord** section within the panel.
+3. Find the new **Get your Farmer role on Discord** section within the panel. **NOTE: This section will not appear if you have not farmed any TSSC yet.**
 ![Wallet Panel](/img/doc-imgs/verify-farmer/wallet-panel.png)
 <br/><br/>
 

--- a/versioned_docs/version-latest/farming-&-staking/farming/additional-guides/verify-farmer.md
+++ b/versioned_docs/version-latest/farming-&-staking/farming/additional-guides/verify-farmer.md
@@ -24,7 +24,7 @@ You can track your farmer through the [Astral Block Explorer.](https://explorer.
 2. Sign into your wallet through Subwallet or Polkadot.
 ![Select Wallet](/img/doc-imgs/verify-farmer/select-wallet.png)
 
-3. Find the new **Get your Farmer role on Discord** section within the panel.
+3. Find the new **Get your Farmer role on Discord** section within the panel. **NOTE: This section will not appear if you have not farmed any TSSC yet.**
 ![Wallet Panel](/img/doc-imgs/verify-farmer/wallet-panel.png)
 <br/><br/>
 


### PR DESCRIPTION
Add note to warn users that the verified role section will not appear on Astral unless they have farmed TSSC.