### PR TITLE
Removing the version line from docker as it is obsolete

### DIFF
--- a/docker-compose-auto.yml
+++ b/docker-compose-auto.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   node:
     # Replace `snapshot-DATE` with the latest release (like `snapshot-2022-apr-29`)

--- a/docs/farming-&-staking/staking/operators/register-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/register-operator.mdx
@@ -143,8 +143,7 @@ You can ignore setting up `your_operator_id` while you're syncing your node. Mak
 <TabItem value="docker" label="🐋 Docker">
 
 <CodeBlock>
-{`version: "3.7"
-services:
+{`services:
   node:
     # Replace snapshot-DATE with the latest release (like snapshot-2022-apr-29)
     # For running on Aarch64 add -aarch64 after DATE

--- a/docs/farming-&-staking/staking/operators/tips-operator.mdx
+++ b/docs/farming-&-staking/staking/operators/tips-operator.mdx
@@ -166,8 +166,7 @@ To run both operator and validator at the same time, provide requrired flags for
 <TabItem value="docker" label="🐋 Docker">
 
 <CodeBlock>
-{`version: "3.7"
-services:
+{`services:
   node:
     # Replace snapshot-DATE with the latest release (like snapshot-2022-apr-29)
     # For running on Aarch64 add -aarch64 after DATE

--- a/src/components/DockerFileGenerator/DockerFileLatest.jsx
+++ b/src/components/DockerFileGenerator/DockerFileLatest.jsx
@@ -97,7 +97,6 @@ function DockerFileGeneratorLatest() {
 	// Only generate the output if there are no validation errors
         if (Object.keys(validationErrors).length === 0) {
             const template = `\
-version: "3.7"
 services:
   node:
     image: ghcr.io/subspace/node:${formData.snapshot}${formData.arch === "aarch64" ? "-aarch64" : ""}

--- a/src/components/DockerFileGenerator/DockerFilePreRelease.jsx
+++ b/src/components/DockerFileGenerator/DockerFilePreRelease.jsx
@@ -97,7 +97,6 @@ function DockerFileGeneratorPreRelease() {
 	// Only generate the output if there are no validation errors
         if (Object.keys(validationErrors).length === 0) {
             const template = `\
-version: "3.7"
 services:
   node:
     image: ghcr.io/subspace/node:${formData.snapshot}${formData.arch === "aarch64" ? "-aarch64" : ""}

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/register-operator.mdx
@@ -143,8 +143,7 @@ You can ignore setting up `your_operator_id` while you're syncing your node. Mak
 <TabItem value="docker" label="🐋 Docker">
 
 <CodeBlock>
-{`version: "3.7"
-services:
+{`services:
   node:
     # Replace snapshot-DATE with the latest release (like snapshot-2022-apr-29)
     # For running on Aarch64 add -aarch64 after DATE

--- a/versioned_docs/version-latest/farming-&-staking/staking/operators/tips-operator.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/staking/operators/tips-operator.mdx
@@ -166,8 +166,7 @@ To run both operator and validator at the same time, provide requrired flags for
 <TabItem value="docker" label="🐋 Docker">
 
 <CodeBlock>
-{`version: "3.7"
-services:
+{`services:
   node:
     # Replace snapshot-DATE with the latest release (like snapshot-2022-apr-29)
     # For running on Aarch64 add -aarch64 after DATE


### PR DESCRIPTION
This removes a warning message when using new versions of docker