### PR TITLE
Add Space Acres macOS download button

### DIFF
--- a/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/docs/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -16,11 +16,18 @@ import styles from '@site/src/pages/index.module.css';
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
-    <Link
+  <Link
     className="button button--secondary"
     to="https://github.com/subspace/space-acres/releases/download/0.1.27/space-acres-0.1.27-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>
+  </Link>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.27/space-acres-0.1.27.dmg"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>macOS Installer</span>
+    <span style={{ fontSize: '14px' }}>(.dmg)</span>
   </Link>
 </div>

--- a/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
+++ b/versioned_docs/version-latest/farming-&-staking/farming/space-acres/platforms/_download.mdx
@@ -16,11 +16,18 @@ import styles from '@site/src/pages/index.module.css';
     <span style={{ fontSize: '20px' }}>Linux Installer</span>
     <span style={{ fontSize: '14px' }}>(.DEB)</span>
   </Link>
-    <Link
+  <Link
     className="button button--secondary"
     to="https://github.com/subspace/space-acres/releases/download/0.1.27/space-acres-0.1.27-x86_64.AppImage"
     style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
     <span style={{ fontSize: '20px' }}>Linux Portable App</span>
     <span style={{ fontSize: '14px' }}>(AppImage)</span>
+  </Link>
+  <Link
+    className="button button--secondary"
+    to="https://github.com/subspace/space-acres/releases/download/0.1.27/space-acres-0.1.27.dmg"
+    style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', justifyContent: 'center', textAlign: 'center', padding: '10px' }}>
+    <span style={{ fontSize: '20px' }}>macOS Installer</span>
+    <span style={{ fontSize: '14px' }}>(.dmg)</span>
   </Link>
 </div>


### PR DESCRIPTION
So macOS users can find the .dmg directly from the docs.